### PR TITLE
Add arrow-height parameter to popover mixin and fix height in points per role

### DIFF
--- a/app/styles/dependencies/mixins.scss
+++ b/app/styles/dependencies/mixins.scss
@@ -31,7 +31,7 @@
     background: rgba($red, $green, $blue, $opacity);
 }
 
-@mixin popover($width, $top: '', $left: '', $bottom: '', $right: '', $arrow-width: 0, $arrow-top: '', $arrow-left: '', $arrow-bottom: '') {
+@mixin popover($width, $top: '', $left: '', $bottom: '', $right: '', $arrow-width: 0, $arrow-top: '', $arrow-left: '', $arrow-bottom: '', $arrow-height: 15px) {
     @extend %text;
     background: $blackish;
     bottom: #{$bottom};
@@ -67,7 +67,7 @@
         background: $blackish;
         bottom: #{$arrow-bottom};
         content: '';
-        height: 15px;
+        height: #{$arrow-height};
         left: #{$arrow-left};
         position: absolute;
         top: #{$arrow-top};

--- a/app/styles/layout/us-detail.scss
+++ b/app/styles/layout/us-detail.scss
@@ -305,7 +305,7 @@
         text-align: center;
     }
     .popover {
-        @include popover(200px, $top: 105%, $left: 35%, $arrow-width: 10px, $arrow-top: -5px, $arrow-left: 10px);
+        @include popover(200px, $top: 105%, $left: 35%, $arrow-width: 10px, $arrow-top: -5px, $arrow-left: 10px, $arrow-height: 10px);
         li {
             display: inline-block;
             width: 23%;
@@ -320,7 +320,7 @@
             }
         }
         &.fix {
-            @include popover(200px, $top: 105%, $left: -160px, $arrow-width: 10px, $arrow-top: -5px, $arrow-left: 90%);
+            @include popover(200px, $top: 105%, $left: -160px, $arrow-width: 10px, $arrow-top: -5px, $arrow-left: 90%, $arrow-height: 10px);
         }
     }
 }


### PR DESCRIPTION
Add arrow-height parameter to popover mixin, it also fixes this bug:

Before 

![before](https://cloud.githubusercontent.com/assets/537363/6036349/2b2a8db4-ac44-11e4-92ec-0b6f4fb8812d.png)

After

![after](https://cloud.githubusercontent.com/assets/537363/6036351/316586ca-ac44-11e4-9117-64ba7b582dec.png)
