### PR TITLE
fix taskboard with 28" screens

### DIFF
--- a/app/partials/taskboard/taskboard.jade
+++ b/app/partials/taskboard/taskboard.jade
@@ -1,17 +1,18 @@
 div.wrapper(tg-taskboard, ng-controller="TaskboardController as ctrl",
             ng-init="section='backlog'")
     section.main.taskboard
-        h1
-            span(tg-bo-bind="project.name", class="project-name-short")
-            span.green(tg-bo-bind="sprint.name")
-            span.date(tg-date-range="sprint.estimated_start,sprint.estimated_finish")
-        include ../includes/components/sprint-summary
+        .taskboard-inner
+            h1
+                span(tg-bo-bind="project.name", class="project-name-short")
+                span.green(tg-bo-bind="sprint.name")
+                span.date(tg-date-range="sprint.estimated_start,sprint.estimated_finish")
+            include ../includes/components/sprint-summary
 
-        div.graphics-container
-            div.burndown(tg-sprint-graph)
-                include ../includes/modules/burndown
+            div.graphics-container
+                div.burndown(tg-sprint-graph)
+                    include ../includes/modules/burndown
 
-        include ../includes/modules/taskboard-table
+            include ../includes/modules/taskboard-table
 
     div.lightbox.lightbox-generic-form(tg-lb-create-edit-task)
         include ../includes/modules/lightbox-task-create-edit

--- a/app/styles/layout/taskboard.scss
+++ b/app/styles/layout/taskboard.scss
@@ -1,7 +1,6 @@
 .taskboard {
-    display: flex;
-    flex-direction: column;
-    max-height: 100vh;
+    height: 100vh;
+    overflow: hidden;
     h1,
     .graphics-container,
     .summary {
@@ -10,4 +9,11 @@
     .graphics-container {
         @include slide(300px, hidden);
     }
+}
+
+.taskboard-inner {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
 }

--- a/app/styles/modules/backlog/taskboard-table.scss
+++ b/app/styles/modules/backlog/taskboard-table.scss
@@ -47,6 +47,7 @@ $column-margin: 0 10px 0 0;
 .taskboard-table {
     display: flex;
     flex-direction: column;
+    height: 100%;
     overflow: hidden;
     width: 100%;
 }
@@ -109,7 +110,7 @@ $column-margin: 0 10px 0 0;
 }
 
 .taskboard-table-body {
-    height: 700px;
+    height: 100%;
     overflow: auto;
     width: 100%;
     .task-column {


### PR DESCRIPTION
the taskboard table should always fill the 100% width and the height much space as it can. The scroll bard only should be visible when needed.

- test with multiples browsers
- test also with empty taskboard
- resize the window
- fold columns