### PR TITLE
fixing pre-commit hook failure due to scss-lint warnings 

### DIFF
--- a/app/styles/components/loading-bar.scss
+++ b/app/styles/components/loading-bar.scss
@@ -13,7 +13,7 @@
         height: 5px;
     }
 
-    $colors-list: #bbe831 #237400 #e43050 #810061 #618000;
+    $colors-list: $yellow-pear $green-japanese-laurel $red-amaranth $purple-eggplant $green-olive;
     @each $current-color in $colors-list {
         $i: index($colors-list, $current-color) - 1;
         .item-#{$i} {

--- a/app/styles/dependencies/colors.scss
+++ b/app/styles/dependencies/colors.scss
@@ -5,8 +5,20 @@ $blackish: #050505;
 $grayer: #444;
 $gray: #555;
 $gray-light: #b8b8b8;
+$gray-tower-gray: #a6b2a7;
+$gray-saltpan: #e9f0da;
+$gray-silver: #cdcdcd;
+$gray46-47: #777;
+$gray60: #999;
+$gray80: #ccc;
+$gray87-88: #ddd;
+$gray-mine-shaft: #232323;
 $whitish: #f5f5f5;
 $white: #fff;
+
+$green-japanese-laurel: #237400;
+$green-olive: #618000;
+$green-christi: #74a218;
 
 $green-taiga: #72a114;
 $fresh-taiga: #9dce0a;
@@ -14,6 +26,10 @@ $dark-taiga: #879b89;
 
 $red-light: #ff8282;
 $red: #f00;
+
+$red-amaranth: #e43050;
+$purple-eggplant: #810061;
+$yellow-pear: #bbe831;
 
 $postit: #fff8e4;
 $postit-hover: #f1e8cd;

--- a/app/styles/layout/base.scss
+++ b/app/styles/layout/base.scss
@@ -5,8 +5,8 @@ html {
 }
 body {
     @extend %text;
-    background: #fff; // fallback
-    color: #444;
+    background: $white; // fallback
+    color: $grayer;
     min-height: 100%;
     width: 100%;
     .master {

--- a/app/styles/layout/base.scss
+++ b/app/styles/layout/base.scss
@@ -138,6 +138,7 @@ body {
 }
 
 .hidden {
+    // scss-lint:disable ImportantRule
     display: none !important;
 }
 

--- a/app/styles/layout/elements.scss
+++ b/app/styles/layout/elements.scss
@@ -3,17 +3,17 @@
 // Blockquotes
 blockquote,
 blockquote p {
-    color: #777;
+    color: $gray46-47;
     font-style: italic;
     line-height: 24px;
 }
 blockquote {
-    border-left: 1px solid #ddd;
+    border-left: 1px solid $gray87-88;
     margin: 0 0 20px;
     padding: 9px 20px 0 19px;
     cite {
         @extend %small;
-        color: #555;
+        color: $gray;
         display: block;
         &:before {
             content: '\2014 \0020';

--- a/app/styles/layout/elements.scss
+++ b/app/styles/layout/elements.scss
@@ -53,6 +53,7 @@ sup {
 
 //Datepicker
 .pika-single {
+    // scss-lint:disable ImportantRule
     z-index: 999999;
     .pika-title {
         color: $grayer;

--- a/app/styles/layout/invitation.scss
+++ b/app/styles/layout/invitation.scss
@@ -100,7 +100,7 @@
         text-align: center;
         width: 200px;
         .form-header {
-            color: #999;
+            color: $gray60;
         }
     }
     .register-form {

--- a/app/styles/layout/typography.scss
+++ b/app/styles/layout/typography.scss
@@ -101,6 +101,7 @@ a:visited {
 // Taiga Icons
 
 [data-icon]:before {
+    // scss-lint:disable ImportantRule
     content: attr(data-icon);
     font-family: 'taiga' !important;
     -moz-osx-font-smoothing: grayscale;
@@ -115,6 +116,7 @@ a:visited {
 
 [class^='icon-']:before,
 [class*=' icon-']:before {
+    // scss-lint:disable ImportantRule
     font-family: 'taiga' !important;
     -moz-osx-font-smoothing: grayscale;
     -webkit-font-smoothing: antialiased;

--- a/app/styles/layout/typography.scss
+++ b/app/styles/layout/typography.scss
@@ -80,7 +80,7 @@ strong {
 }
 
 hr {
-    border: solid #ddd;
+    border: solid $gray87-88;
     border-width: 1px 0 0;
     clear: both;
     height: 0;

--- a/app/styles/modules/admin/admin-functionalities.scss
+++ b/app/styles/modules/admin/admin-functionalities.scss
@@ -19,7 +19,7 @@
         vertical-align: top;
         width: 32%;
         &.active {
-            background-color: #e9f0da;
+            background-color: $gray-saltpan;
             opacity: 1;
         }
         .icon {

--- a/app/styles/modules/admin/admin-membership-table.scss
+++ b/app/styles/modules/admin/admin-membership-table.scss
@@ -139,7 +139,7 @@
         }
         input:checked {
             + div {
-                background-color: #74a218;
+                background-color: $green-christi;
                 margin-left: 50%;
                 transition: all .2s linear;
             }

--- a/app/styles/modules/admin/admin-roles.scss
+++ b/app/styles/modules/admin/admin-roles.scss
@@ -88,7 +88,7 @@
         }
         input:checked {
             + div {
-                background-color: #74a218;
+                background-color: $green-christi;
                 margin-left: 50%;
                 transition: all .2s linear;
             }
@@ -104,7 +104,7 @@
         input:disabled {
             cursor: auto;
             + div {
-                background-color: #ccc;
+                background-color: $gray80;
             }
         }
     }

--- a/app/styles/modules/admin/admin-submenu-roles.scss
+++ b/app/styles/modules/admin/admin-submenu-roles.scss
@@ -6,7 +6,7 @@
     li {
         @extend %larger;
         @extend %title;
-        border-bottom: 1px solid #a6b2a7;
+        border-bottom: 1px solid $gray-tower-gray;
         text-transform: uppercase;
         &:last-child {
             border-bottom: 0;

--- a/app/styles/modules/admin/admin-submenu.scss
+++ b/app/styles/modules/admin/admin-submenu.scss
@@ -6,7 +6,7 @@
     li {
         @extend %larger;
         @extend %title;
-        border-bottom: 1px solid #a6b2a7;
+        border-bottom: 1px solid $gray-tower-gray;
         text-transform: uppercase;
         &:last-child {
             border-bottom: 0;

--- a/app/styles/modules/backlog/backlog-table.scss
+++ b/app/styles/modules/backlog/backlog-table.scss
@@ -189,6 +189,7 @@
             transition: background .2s ease-in;
         }
         a {
+            // scss-lint:disable ImportantRule
             color: $white !important;
             &:hover {
                 color: $white;

--- a/app/styles/modules/common/projects-nav.scss
+++ b/app/styles/modules/common/projects-nav.scss
@@ -1,5 +1,5 @@
 .projects-nav {
-    background-color: #232323;
+    background-color: $gray-mine-shaft;
     display: flex;
     flex-direction: column;
     height: 100%;

--- a/app/styles/modules/common/related-tasks.scss
+++ b/app/styles/modules/common/related-tasks.scss
@@ -136,6 +136,7 @@
         background: $red-light;
         color: $white;
         a {
+            // scss-lint:disable ImportantRule
             color: $white !important;
             &:hover {
                 color: $white;

--- a/app/styles/modules/wiki/wiki-nav.scss
+++ b/app/styles/modules/wiki/wiki-nav.scss
@@ -2,7 +2,7 @@
     li {
         @extend %large;
         @extend %title;
-        border-bottom: 1px solid #cdcdcd;
+        border-bottom: 1px solid $gray-silver;
         text-transform: uppercase;
         &:hover {
             .icon {


### PR DESCRIPTION
I will update this PR (if desired) once I know the desired approach to the remaining instances of the issue.

Symptom:
The scss-lint task invoked by the pre-commit hook fails, blocking commits unless --no-verify is passed.

Cause:
Two lint rules fail across 14 files: 20 ColorVariable and 17 ImportantRule warnings.
(The attached PR fixes 3 of the ColorVariable warnings by replacing color literals with color variables already defined in app/styles/dependencies/colors.scss)

Possible Solutions:

1. The simplest approach would be to override the default scss-lint config by setting enabled to false for these two linters in .scss-lint.yml. It's clean but future committers will not be notified if they introduce new code that violates these two best practices.

2. The most pedantic approach would be to add inline comments disabling the ImportantRule linter for those blocks that use it, and either do the same for blocks that use color literals or create variables for each color literal used and thus avoid that warning. (Note, however, that 11 of the 14 remaining (after this PR) literal color references are used only once, and the remaining three are only used twice. An even more nuanced approach would be to create variables for just the three duplicated literals and use inline comment exemptions for the rest.)

Let me know, how, if at all, I should proceed further.