### PR TITLE
Add force parameter for selectFilter and replaceFilter

### DIFF
--- a/app/coffee/modules/controllerMixins.coffee
+++ b/app/coffee/modules/controllerMixins.coffee
@@ -65,7 +65,7 @@ taiga.PageMixin = PageMixin
 # This mixin requires @location ($tgLocation), and @scope
 
 class FiltersMixin
-    selectFilter: (name, value, load=false) ->
+    selectFilter: (name, value, load=false, force=true) ->
         params = @location.search()
         if params[name] != undefined and name != "page"
             existing = _.map(taiga.toString(params[name]).split(","), (x) -> trim(x))
@@ -73,12 +73,12 @@ class FiltersMixin
             existing = _.compact(existing)
             value = joinStr(",", _.uniq(existing))
 
-        if !@location.isInCurrentRouteParams(name, value)
+        if !@location.isInCurrentRouteParams(name, value) or force
             location = if load then @location else @location.noreload(@scope)
             location.search(name, value)
 
-    replaceFilter: (name, value, load=false) ->
-        if !@location.isInCurrentRouteParams(name, value)
+    replaceFilter: (name, value, load=false, force=false) ->
+        if !@location.isInCurrentRouteParams(name, value) or force
             location = if load then @location else @location.noreload(@scope)
             location.search(name, value)
 

--- a/app/coffee/modules/issues/list.coffee
+++ b/app/coffee/modules/issues/list.coffee
@@ -376,13 +376,13 @@ IssuesDirective = ($log, $location, $template, $compile) ->
             event.preventDefault()
 
             $scope.$apply ->
-                $ctrl.selectFilter("page", $scope.page + 1)
+                $ctrl.selectFilter("page", $scope.page + 1, false, true)
                 $ctrl.loadIssues()
 
         $el.on "click", ".issues-paginator a.previous", (event) ->
             event.preventDefault()
             $scope.$apply ->
-                $ctrl.selectFilter("page", $scope.page - 1)
+                $ctrl.selectFilter("page", $scope.page - 1, false, true)
                 $ctrl.loadIssues()
 
         $el.on "click", ".issues-paginator li.page > a", (event) ->
@@ -391,7 +391,7 @@ IssuesDirective = ($log, $location, $template, $compile) ->
             pagenum = target.data("pagenum")
 
             $scope.$apply ->
-                $ctrl.selectFilter("page", pagenum)
+                $ctrl.selectFilter("page", pagenum, false, true)
                 $ctrl.loadIssues()
 
     ## Issues Filters
@@ -412,7 +412,7 @@ IssuesDirective = ($log, $location, $template, $compile) ->
             finalOrder = if currentOrder == newOrder then "-#{newOrder}" else newOrder
 
             $scope.$apply ->
-                $ctrl.replaceFilter("orderBy", finalOrder)
+                $ctrl.replaceFilter("orderBy", finalOrder, false, true)
                 $ctrl.storeFilters()
                 $ctrl.loadIssues().then ->
                     # Update the arrow
@@ -542,13 +542,13 @@ IssuesFiltersDirective = ($log, $location, $rs, $confirm, $loading, $template, $
         selectQFilter = debounceLeading 100, (value) ->
             return if value is undefined
 
-            $ctrl.replaceFilter("page", null)
+            $ctrl.replaceFilter("page", null, false, true)
 
             if value.length == 0
-                $ctrl.replaceFilter("q", null)
+                $ctrl.replaceFilter("q", null, false, true)
                 $ctrl.storeFilters()
             else
-                $ctrl.replaceFilter("q", value)
+                $ctrl.replaceFilter("q", value, false, true)
                 $ctrl.storeFilters()
             $ctrl.loadIssues()
 


### PR DESCRIPTION
I wasn't able to go back to page 1 in Issues section, and when I tried to filter using the previous selected criteria ("-subject" in my case) it didn't work. 

The problem is that replaceFilter and selectFilter look for the current name in the route.current.params, that remains set to 

    {page: "1", orderBy: "-subject", pslug: "user6532909695705815086-project-example-0"}

that's why I add a "force" parameter to skip this check and don't break the code somewhere else. Any hint is appreciated :)