### PR TITLE
Search results table now shows the Ref for each item

### DIFF
--- a/app/locales/locale-en.json
+++ b/app/locales/locale-en.json
@@ -125,7 +125,8 @@
             "ASSIGNED_TO": "Assigned to",
             "POINTS": "Points",
             "BLOCKED_NOTE": "blocked note",
-            "IS_BLOCKED": "is blocked"
+            "IS_BLOCKED": "is blocked",
+            "REF": "Ref"
         },
         "ROLES": {
             "ALL": "All"

--- a/app/partials/includes/modules/search-result-table.jade
+++ b/app/partials/includes/modules/search-result-table.jade
@@ -10,7 +10,7 @@ script(type="text/ng-template", id="search-issues")
                 div.assigned-to(translate="COMMON.FIELDS.ASSIGNED_TO")
         div.search-result-table-body
             div.row.table-main(ng-repeat="issue in issues track by issue.id")
-                div.ref(tg-bo-bind="issue.ref")
+                div.ref(tg-bo-ref="issue.ref")
                 div.user-stories
                     div.user-story-name
                         a(href="", tg-nav="project-issues-detail:project=project.slug,ref=issue.ref",
@@ -34,7 +34,7 @@ script(type="text/ng-template", id="search-userstories")
                 div.points(translate="COMMON.FIELDS.POINTS")
         div.search-result-table-body
             div.row.table-main(ng-repeat="us in userstories track by us.id")
-                div.ref(tg-bo-bind="us.ref")
+                div.ref(tg-bo-ref="us.ref")
                 div.user-stories
                     div.user-story-name
                         a(href="", tg-nav="project-userstories-detail:project=project.slug,ref=us.ref",
@@ -57,7 +57,7 @@ script(type="text/ng-template", id="search-tasks")
                 div.assigned-to(translate="COMMON.FIELDS.ASSIGNED_TO")
         div.search-result-table-body
             div.row.table-main(ng-repeat="task in tasks track by task.id")
-                div.ref(tg-bo-bind="task.ref")
+                div.ref(tg-bo-ref="task.ref")
                 div.user-stories
                     div.user-story-name
                         a(href="", tg-nav="project-tasks-detail:project=project.slug,ref=task.ref",

--- a/app/partials/includes/modules/search-result-table.jade
+++ b/app/partials/includes/modules/search-result-table.jade
@@ -4,11 +4,13 @@ script(type="text/ng-template", id="search-issues")
     div.search-result-table-container(ng-class="{'hidden': !issues.length}", tg-bind-scope)
         div.search-result-table-header
             div.row.title
+                div.ref(translate="COMMON.FIELDS.REF")
                 div.user-stories(translate="SEARCH.FILTER_ISSUES")
                 div.status(translate="COMMON.FIELDS.STATUS")
                 div.assigned-to(translate="COMMON.FIELDS.ASSIGNED_TO")
         div.search-result-table-body
             div.row.table-main(ng-repeat="issue in issues track by issue.id")
+                div.ref(tg-bo-bind="issue.ref")
                 div.user-stories
                     div.user-story-name
                         a(href="", tg-nav="project-issues-detail:project=project.slug,ref=issue.ref",
@@ -26,11 +28,13 @@ script(type="text/ng-template", id="search-userstories")
     div.search-result-table-container(ng-class="{'hidden': !userstories.length}", tg-bind-scope)
         div.search-result-table-header
             div.row.title
+                div.ref(translate="COMMON.FIELDS.REF")
                 div.user-stories(translate="SEARCH.FILTER_USER_STORIES")
                 div.status(translate="COMMON.FIELDS.STATUS")
                 div.points(translate="COMMON.FIELDS.POINTS")
         div.search-result-table-body
             div.row.table-main(ng-repeat="us in userstories track by us.id")
+                div.ref(tg-bo-bind="us.ref")
                 div.user-stories
                     div.user-story-name
                         a(href="", tg-nav="project-userstories-detail:project=project.slug,ref=us.ref",
@@ -47,11 +51,13 @@ script(type="text/ng-template", id="search-tasks")
     div.search-result-table-container(ng-class="{'hidden': !tasks.length}", tg-bind-scope)
         div.search-result-table-header
             div.row.title
+                div.ref(translate="COMMON.FIELDS.REF")
                 div.user-stories(translate="SEARCH.FILTER_TASKS")
                 div.status(translate="COMMON.FIELDS.STATUS")
                 div.assigned-to(translate="COMMON.FIELDS.ASSIGNED_TO")
         div.search-result-table-body
             div.row.table-main(ng-repeat="task in tasks track by task.id")
+                div.ref(tg-bo-bind="task.ref")
                 div.user-stories
                     div.user-story-name
                         a(href="", tg-nav="project-tasks-detail:project=project.slug,ref=task.ref",

--- a/app/styles/modules/search/search-result-table.scss
+++ b/app/styles/modules/search/search-result-table.scss
@@ -15,6 +15,11 @@
             background: lighten($green-taiga, 60%);
             transition: background .2s ease-in;
         }
+        .ref {
+            flex-basis: 30px;
+            flex-grow: 1;
+            padding: 0 1rem;
+        }
         .user-stories {
             flex-basis: 0;
             flex-grow: 5;


### PR DESCRIPTION
Related to pull request 337 on taiga-back, although they are not dependent on each other.

This pull request adds the Ref number as a column on the search results for user stories, issues & tasks. 
Also added REF in to the English locale file - its beyond my skill set to translate to other languages I'm afraid :-) 