### PR TITLE
Autofocus on the search textbox when the modal opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 - Show the reference of entities in search results (thanks to [@artlepool](https://github.com/artlepool))
+- Autofocus on textbox after opening search modal 
 
 ### Misc
 - Improve performance: remove some unnecessary calls to the api.

--- a/app/coffee/modules/search.coffee
+++ b/app/coffee/modules/search.coffee
@@ -133,6 +133,10 @@ SearchBoxDirective = ($lightboxService, $navurls, $location, $route)->
             $lightboxService.open($el)
             $el.find("#search-text").val("")
 
+            setTimeout (->
+              $el.find('#search-text').focus()
+            ), 100
+
         $el.on "submit", "form", submit
 
     return {link:link}


### PR DESCRIPTION
Hi!

For speed, and as only one textbox/action shows on screen it would be good if the users text input automatically focused on the search textbox once they click search from the side navigation bar and the modal shows. 