### PR TITLE
close description and subject fields if they are open after a change

### DIFF
--- a/app/coffee/modules/common/components.coffee
+++ b/app/coffee/modules/common/components.coffee
@@ -220,7 +220,7 @@ WatchersDirective = ($rootscope, $confirm, $repo, $qqueue, $template, $compile, 
                 $confirm.notify("success")
                 watchers = _.map(watchers, (watcherId) -> $scope.usersById[watcherId])
                 renderWatchers(watchers)
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
 
             promise.then null, ->
                 $model.$modelValue.revert()
@@ -235,7 +235,7 @@ WatchersDirective = ($rootscope, $confirm, $repo, $qqueue, $template, $compile, 
                 $confirm.notify("success")
                 watchers = _.map(item.watchers, (watcherId) -> $scope.usersById[watcherId])
                 renderWatchers(watchers)
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
             promise.then null, ->
                 item.revert()
                 $confirm.notify("error")
@@ -321,7 +321,7 @@ AssignedToDirective = ($rootscope, $confirm, $repo, $loading, $qqueue, $template
                 $loading.finish($el)
                 $confirm.notify("success")
                 renderAssignedTo($model.$modelValue)
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
             promise.then null, ->
                 $model.$modelValue.revert()
                 $confirm.notify("error")
@@ -474,6 +474,10 @@ EditableSubjectDirective = ($rootscope, $repo, $confirm, $loading, $qqueue, $tem
 
     link = ($scope, $el, $attrs, $model) ->
 
+        $scope.$on "object:updated", () ->
+            $el.find('.edit-subject').hide()
+            $el.find('.view-subject').show()
+
         isEditable = ->
             return $scope.project.my_permissions.indexOf($attrs.requiredPerm) != -1
 
@@ -485,7 +489,7 @@ EditableSubjectDirective = ($rootscope, $repo, $confirm, $loading, $qqueue, $tem
             promise = $repo.save($model.$modelValue)
             promise.then ->
                 $confirm.notify("success")
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
                 $el.find('.edit-subject').hide()
                 $el.find('.view-subject').show()
             promise.then null, ->
@@ -553,6 +557,10 @@ EditableDescriptionDirective = ($rootscope, $repo, $confirm, $compile, $loading,
         $el.find('.edit-description').hide()
         $el.find('.view-description .edit').hide()
 
+        $scope.$on "object:updated", () ->
+            $el.find('.edit-description').hide()
+            $el.find('.view-description').show()
+
         isEditable = ->
             return $scope.project.my_permissions.indexOf($attrs.requiredPerm) != -1
 
@@ -563,7 +571,7 @@ EditableDescriptionDirective = ($rootscope, $repo, $confirm, $compile, $loading,
             promise = $repo.save($model.$modelValue)
             promise.then ->
                 $confirm.notify("success")
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
                 $el.find('.edit-description').hide()
                 $el.find('.view-description').show()
             promise.then null, ->

--- a/app/coffee/modules/common/estimation.coffee
+++ b/app/coffee/modules/common/estimation.coffee
@@ -92,7 +92,7 @@ UsEstimationDirective = ($tgEstimationsService, $rootScope, $repo, $confirm, $qq
                 estimationProcess = $tgEstimationsService.create($el, us, $scope.project)
                 estimationProcess.onSelectedPointForRole = (roleId, pointId) ->
                     @save(roleId, pointId).then ->
-                        $rootScope.$broadcast("history:reload")
+                        $rootScope.$broadcast("object:updated")
 
                 estimationProcess.render = () ->
                     ctx = {

--- a/app/coffee/modules/common/history.coffee
+++ b/app/coffee/modules/common/history.coffee
@@ -371,7 +371,7 @@ HistoryDirective = ($log, $loading, $qqueue, $template, $confirm, $translate, $c
         $scope.$watch("comments", renderComments)
         $scope.$watch("history",  renderActivity)
 
-        $scope.$on("history:reload", -> $ctrl.loadHistory(type, objectId))
+        $scope.$on("object:updated", -> $ctrl.loadHistory(type, objectId))
 
         # Events
 

--- a/app/coffee/modules/common/lightboxes.coffee
+++ b/app/coffee/modules/common/lightboxes.coffee
@@ -161,7 +161,7 @@ BlockLightboxDirective = ($rootscope, $tgrepo, $confirm, lightboxService, $loadi
             promise = $tgrepo.save(item)
             promise.then ->
                 $confirm.notify("success")
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
                 $model.$setViewValue(item)
                 finishCallback()
 
@@ -183,7 +183,7 @@ BlockLightboxDirective = ($rootscope, $tgrepo, $confirm, lightboxService, $loadi
             promise = $tgrepo.save($model.$modelValue)
             promise.then ->
                 $confirm.notify("success")
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
 
             promise.then null, ->
                 $confirm.notify("error")

--- a/app/coffee/modules/common/tags.coffee
+++ b/app/coffee/modules/common/tags.coffee
@@ -285,7 +285,7 @@ TagLineDirective = ($rootScope, $repo, $rs, $confirm, $qqueue, $template, $compi
             $model.$setViewValue(model)
 
             onSuccess = ->
-                $rootScope.$broadcast("history:reload")
+                $rootScope.$broadcast("object:updated")
             onError = ->
                 $confirm.notify("error")
                 model.revert()
@@ -306,7 +306,7 @@ TagLineDirective = ($rootScope, $repo, $rs, $confirm, $qqueue, $template, $compi
             $model.$setViewValue(model)
 
             onSuccess = ->
-                $rootScope.$broadcast("history:reload")
+                $rootScope.$broadcast("object:updated")
             onError = ->
                 $confirm.notify("error")
                 model.revert()

--- a/app/coffee/modules/issues/detail.coffee
+++ b/app/coffee/modules/issues/detail.coffee
@@ -68,22 +68,22 @@ class IssueDetailController extends mixOf(taiga.Controller, taiga.PageMixin)
 
     initializeEventHandlers: ->
         @scope.$on "attachment:create", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
             @analytics.trackEvent("attachment", "create", "create attachment on issue", 1)
 
         @scope.$on "attachment:edit", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
 
         @scope.$on "attachment:delete", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
 
         @scope.$on "promote-issue-to-us:success", =>
             @analytics.trackEvent("issue", "promoteToUserstory", "promote issue to userstory", 1)
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
             @.loadIssue()
 
         @scope.$on "custom-attributes-values:edit", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
 
     initializeOnDeleteGoToUrl: ->
        ctx = {project: @scope.project.slug}
@@ -225,7 +225,7 @@ IssueStatusButtonDirective = ($rootScope, $repo, $confirm, $loading, $qqueue, $t
             onSuccess = ->
                 $confirm.notify("success")
                 $model.$setViewValue(issue)
-                $rootScope.$broadcast("history:reload")
+                $rootScope.$broadcast("object:updated")
                 $loading.finish($el.find(".level-name"))
             onError = ->
                 $confirm.notify("error")
@@ -309,7 +309,7 @@ IssueTypeButtonDirective = ($rootScope, $repo, $confirm, $loading, $qqueue, $tem
             onSuccess = ->
                 $confirm.notify("success")
                 $model.$setViewValue(issue)
-                $rootScope.$broadcast("history:reload")
+                $rootScope.$broadcast("object:updated")
                 $loading.finish($el.find(".level-name"))
 
             onError = ->
@@ -395,7 +395,7 @@ IssueSeverityButtonDirective = ($rootScope, $repo, $confirm, $loading, $qqueue, 
             onSuccess = ->
                 $confirm.notify("success")
                 $model.$setViewValue(issue)
-                $rootScope.$broadcast("history:reload")
+                $rootScope.$broadcast("object:updated")
                 $loading.finish($el.find(".level-name"))
             onError = ->
                 $confirm.notify("error")
@@ -482,7 +482,7 @@ IssuePriorityButtonDirective = ($rootScope, $repo, $confirm, $loading, $qqueue, 
             onSuccess = ->
                 $confirm.notify("success")
                 $model.$setViewValue(issue)
-                $rootScope.$broadcast("history:reload")
+                $rootScope.$broadcast("object:updated")
                 $loading.finish($el.find(".level-name"))
             onError = ->
                 $confirm.notify("error")

--- a/app/coffee/modules/tasks/detail.coffee
+++ b/app/coffee/modules/tasks/detail.coffee
@@ -65,13 +65,13 @@ class TaskDetailController extends mixOf(taiga.Controller, taiga.PageMixin)
     initializeEventHandlers: ->
         @scope.$on "attachment:create", =>
             @analytics.trackEvent("attachment", "create", "create attachment on task", 1)
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
         @scope.$on "attachment:edit", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
         @scope.$on "attachment:delete", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
         @scope.$on "custom-attributes-values:edit", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
 
     initializeOnDeleteGoToUrl: ->
         ctx = {project: @scope.project.slug}
@@ -237,7 +237,7 @@ TaskStatusButtonDirective = ($rootScope, $repo, $confirm, $loading, $qqueue, $co
 
             onSuccess = ->
                 $confirm.notify("success")
-                $rootScope.$broadcast("history:reload")
+                $rootScope.$broadcast("object:updated")
                 $loading.finish($el.find(".level-name"))
 
             onError = ->
@@ -322,7 +322,7 @@ TaskIsIocaineButtonDirective = ($rootscope, $tgrepo, $confirm, $loading, $qqueue
 
             promise.then ->
                 $confirm.notify("success")
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
 
             promise.then null, ->
                 task.revert()

--- a/app/coffee/modules/userstories/detail.coffee
+++ b/app/coffee/modules/userstories/detail.coffee
@@ -71,16 +71,16 @@ class UserStoryDetailController extends mixOf(taiga.Controller, taiga.PageMixin)
 
         @scope.$on "attachment:create", =>
             @analytics.trackEvent("attachment", "create", "create attachment on userstory", 1)
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
 
         @scope.$on "attachment:edit", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
 
         @scope.$on "attachment:delete", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
 
         @scope.$on "custom-attributes-values:edit", =>
-            @rootscope.$broadcast("history:reload")
+            @rootscope.$broadcast("object:updated")
 
     initializeOnDeleteGoToUrl: ->
         ctx = {project: @scope.project.slug}
@@ -297,6 +297,7 @@ UsStatusButtonDirective = ($rootScope, $repo, $confirm, $loading, $qqueue, $temp
 
         save = $qqueue.bindAdd (status) =>
             us = $model.$modelValue.clone()
+
             us.status = status
 
             $.fn.popover().closeAll()
@@ -305,7 +306,7 @@ UsStatusButtonDirective = ($rootScope, $repo, $confirm, $loading, $qqueue, $temp
 
             onSuccess = ->
                 $confirm.notify("success")
-                $rootScope.$broadcast("history:reload")
+                $rootScope.$broadcast("object:updated")
                 $loading.finish($el.find(".level-name"))
 
             onError = ->
@@ -387,7 +388,7 @@ UsTeamRequirementButtonDirective = ($rootscope, $tgrepo, $confirm, $loading, $qq
             promise = $tgrepo.save($model.$modelValue)
             promise.then =>
                 $loading.finish($el.find("label"))
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
 
             promise.then null, ->
                 $loading.finish($el.find("label"))
@@ -449,7 +450,7 @@ UsClientRequirementButtonDirective = ($rootscope, $tgrepo, $confirm, $loading, $
             promise = $tgrepo.save($model.$modelValue)
             promise.then =>
                 $loading.finish($el.find("label"))
-                $rootscope.$broadcast("history:reload")
+                $rootscope.$broadcast("object:updated")
             promise.then null, ->
                 $loading.finish($el.find("label"))
                 $confirm.notify("error")


### PR DESCRIPTION
In a issue/task/userstory after save a field, it must close other editable fields like description or subject