### PR TITLE
Fix issue 2817 - us backlog drag position at start

### DIFF
--- a/app/coffee/modules/backlog/sortable.coffee
+++ b/app/coffee/modules/backlog/sortable.coffee
@@ -61,10 +61,10 @@ BacklogSortableDirective = ($repo, $rs, $rootscope, $tgConfirm, $translate) ->
                 items: ".us-item-row",
                 cancel: ".popover"
                 connectWith: ".sprint"
-                containment: ".wrapper"
                 dropOnEmpty: true
                 placeholder: "row us-item-row us-item-drag sortable-placeholder"
                 scroll: true
+                disableHorizontalScroll: true
                 # A consequence of length of backlog user story item
                 # the default tolerance ("intersection") not works properly.
                 tolerance: "pointer"
@@ -73,8 +73,11 @@ BacklogSortableDirective = ($repo, $rs, $rootscope, $tgConfirm, $translate) ->
                 # works unexpectly (in some circumstances calculates wrong
                 # position for revert).
                 revert: false
-                cursorAt: {right: 15}
+                start: () ->
+                    $(document.body).addClass("drag-active")
                 stop: () ->
+                    $(document.body).removeClass("drag-active")
+
                     if $el.hasClass("active-filters")
                         $el.sortable("cancel")
                         filterError()
@@ -167,9 +170,10 @@ SprintSortableDirective = ($repo, $rs, $rootscope) ->
                 $el.sortable({
                     scroll: true
                     dropOnEmpty: true
-                    items: ".sprint-table .milestone-us-item-row",
-                    connectWith: ".sprint,.backlog-table-body,.empty-backlog",
-                    placeholder: "row us-item-row sortable-placeholder",
+                    items: ".sprint-table .milestone-us-item-row"
+                    containment: "window"
+                    connectWith: ".sprint,.backlog-table-body,.empty-backlog"
+                    placeholder: "row us-item-row sortable-placeholder"
                     forcePlaceholderSize:true
                 })
 

--- a/app/js/jquery.ui.git-custom.js
+++ b/app/js/jquery.ui.git-custom.js
@@ -4508,6 +4508,7 @@ var sortable = $.widget("ui.sortable", $.ui.mouse, {
 		scroll: true,
 		scrollSensitivity: 20,
 		scrollSpeed: 20,
+        disableHorizontalScroll: false,
 		scope: "default",
 		tolerance: "intersect",
 		zIndex: 1000,
@@ -4804,11 +4805,14 @@ var sortable = $.widget("ui.sortable", $.ui.mouse, {
 					scrolled = this.document.scrollTop(this.document.scrollTop() + o.scrollSpeed);
 				}
 
-				if(event.pageX - this.document.scrollLeft() < o.scrollSensitivity) {
-					scrolled = this.document.scrollLeft(this.document.scrollLeft() - o.scrollSpeed);
-				} else if(this.window.width() - (event.pageX - this.document.scrollLeft()) < o.scrollSensitivity) {
-					scrolled = this.document.scrollLeft(this.document.scrollLeft() + o.scrollSpeed);
-				}
+                // taiga
+                if (!this.options.disableHorizontalScroll) {
+				    if(event.pageX - this.document.scrollLeft() < o.scrollSensitivity) {
+					    scrolled = this.document.scrollLeft(this.document.scrollLeft() - o.scrollSpeed);
+				    } else if(this.window.width() - (event.pageX - this.document.scrollLeft()) < o.scrollSensitivity) {
+					    scrolled = this.document.scrollLeft(this.document.scrollLeft() + o.scrollSpeed);
+				    }
+                }
 
 			}
 

--- a/app/styles/core/base.scss
+++ b/app/styles/core/base.scss
@@ -33,6 +33,10 @@ body {
     overflow: hidden;
 }
 
+.drag-active {
+    overflow-x: hidden;
+}
+
 .master {
     background: $white;
     height: 100%;


### PR DESCRIPTION
- Before when the user clicked on the left of a backlog US, the US position try to reach the drag icon.
- Now when the US starts dragging preserve their position and if you move it to the sprint the US overflowing the X without scroll.