### PR TITLE
Fix jitsi menu link, now appear on the left menu links

### DIFF
--- a/app/modules/components/project-menu/project-menu.controller.coffee
+++ b/app/modules/components/project-menu/project-menu.controller.coffee
@@ -79,6 +79,8 @@ class ProjectMenuController
             baseUrl = "https://appear.in/"
         else if @.project.get("videoconferences") == "talky"
             baseUrl = "https://talky.io/"
+        else if @.project.get("videoconferences") == "jitsi"
+            baseUrl = "https://meet.jit.si/"
         else
             return ""
 


### PR DESCRIPTION
The link in the menu doesn't appear when select jitsi as conference system.