### PR TITLE
Multi-line custom field types (taiga-front #451)

### DIFF
--- a/app/coffee/modules/common/custom-field-values.coffee
+++ b/app/coffee/modules/common/custom-field-values.coffee
@@ -128,6 +128,7 @@ CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
     link = ($scope, $el, $attrs, $ctrl) ->
         render = (attributeValue, edit=false) ->
             value = attributeValue.value
+            innerText = attributeValue.value
             editable = isEditable()
             ctx = {
                 id: attributeValue.id
@@ -135,6 +136,7 @@ CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
                 description: attributeValue.description
                 value: value
                 isEditable: editable
+                field_type: attributeValue.field_type
             }
 
             if editable and (edit or not value)
@@ -152,14 +154,14 @@ CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
             return permissions.indexOf(requiredEditionPerm) > -1
 
         saveAttributeValue = ->
-            attributeValue.value = $el.find("input").val()
+            attributeValue.value = $el.find("input, textarea").val()
 
             $scope.$apply ->
                 $ctrl.updateAttributeValue(attributeValue).then ->
                     render(attributeValue, false)
 
-        $el.on "keyup", "input[name=description]", (event) ->
-            if event.keyCode == 13
+        $el.on "keyup", "input[name=description], textarea[name='description']", (event) ->
+            if event.keyCode == 13 and event.currentTarget.type != "textarea"
                 submit(event)
             else if event.keyCode == 27
                 render(attributeValue, false)
@@ -169,14 +171,12 @@ CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
             return if not isEditable()
             return if $selectedText.get().length
             render(attributeValue, true)
-            $el.find("input[name='description']").focus().select()
-            $scope.$apply()
+            $el.find("input[name='description'], textarea[name='description']").focus().select()
 
         $el.on "click", "a.icon-edit", (event) ->
             event.preventDefault()
             render(attributeValue, true)
-            $el.find("input[name='description']").focus().select()
-            $scope.$apply() 
+            $el.find("input[name='description'], textarea[name='description']").focus().select()
 
         ## Actions (on edit mode)
         submit = debounce 2000, (event) =>

--- a/app/locales/locale-en.json
+++ b/app/locales/locale-en.json
@@ -448,7 +448,9 @@
             "TASK_DESCRIPTION": "Tasks custom fields",
             "TASK_ADD": "Add a custom field in tasks",
             "ISSUE_DESCRIPTION": "Issues custom fields",
-            "ISSUE_ADD": "Add a custom field in issues"
+            "ISSUE_ADD": "Add a custom field in issues",
+            "FIELD_TYPE_TEXT": "Text",
+            "FIELD_TYPE_MULTI": "Multi-line"
         },
         "PROJECT_VALUES": {
             "PAGE_TITLE": "{{sectionName}} - Project values - {{projectName}}",

--- a/app/partials/custom-attributes/custom-attribute-value-edit.jade
+++ b/app/partials/custom-attributes/custom-attribute-value-edit.jade
@@ -8,7 +8,15 @@ form.custom-field-single.editable
         <% } %>
 
     div.custom-field-value
+        
+        <% if (field_type=="MULTI") { %>
+        textarea#custom-field-description(name="description")
+            <%- value %>
+        <% } %>
+
+        <% if (field_type=="TEXT") { %>
         input#custom-field-description(name="description", type="text", value!="<%- value %>")
+        <% } %>
 
     div.custom-field-options
         a.icon.icon-floppy(href="", title="{{'COMMON.CUSTOM_ATTRIBUTES.SAVE' | translate}}")

--- a/app/partials/includes/modules/admin/admin-custom-attributes.jade
+++ b/app/partials/includes/modules/admin/admin-custom-attributes.jade
@@ -10,6 +10,8 @@ section.custom-fields-table.basic-table
                 span(translate="COMMON.FIELDS.NAME")
             div.custom-description
                 span(translate="COMMON.FIELDS.DESCRIPTION")
+            div.custom-field-type
+                span(translate="COMMON.FIELDS.FIELD_TYPE")
             div.custom-options
 
     div.table-body
@@ -21,6 +23,8 @@ section.custom-fields-table.basic-table
                         span {{ attr.name }}
                     div.custom-description
                         span {{ attr.description }}
+                    div.custom-field-type
+                        span(translate="ADMIN.CUSTOM_FIELDS.FIELD_TYPE_{{ attr.field_type }}")
                     div.custom-options
                         div.custom-options-wrapper
                             a.js-edit-custom-field-button.icon.icon-edit(href="", title="{{'ADMIN.CUSTOM_ATTRIBUTES.EDIT' | translate}}")
@@ -33,6 +37,9 @@ section.custom-fields-table.basic-table
                     fieldset.custom-description
                         input(type="text", name="description", placeholder="{{'ADMIN.CUSTOM_ATTRIBUTES.SET_FIELD_DESCRIPTION' | translate}}",
                               ng-model="attr.description")
+                    fieldset.custom-field-type
+                        select(ng-model="attr.field_type",
+                               ng-options="e.id as e.name | translate for e in [{'id':'TEXT', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_TEXT'},{'id':'MULTI', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_MULTI'}]")
 
                     fieldset.custom-options
                         div.custom-options-wrapper
@@ -46,7 +53,9 @@ section.custom-fields-table.basic-table
             fieldset.custom-description
                 input(type="text", name="description", placeholder="{{'ADMIN.CUSTOM_ATTRIBUTES.SET_FIELD_DESCRIPTION' | translate}}",
                       ng-model="newAttr.description")
-
+            fieldset.custom-field-type
+                select(ng-model="newAttr.field_type",
+                      ng-options="e.id as translate(e.name) for e in [{'id':'TEXT', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_TEXT'},{'id':'MULTI', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_MULTI'}]")
             fieldset.custom-options
                 div.custom-options-wrapper
                     a.js-create-custom-field-button.icon.icon-floppy(href="", title="{{'ADMIN.CUSTOM_ATTRIBUTES.SAVE_TITLE' | translate}}")

--- a/app/partials/includes/modules/admin/admin-custom-attributes.jade
+++ b/app/partials/includes/modules/admin/admin-custom-attributes.jade
@@ -11,7 +11,7 @@ section.custom-fields-table.basic-table
             div.custom-description
                 span(translate="COMMON.FIELDS.DESCRIPTION")
             div.custom-field-type
-                span(translate="COMMON.FIELDS.FIELD_TYPE")
+                span(translate="COMMON.FIELDS.TYPE")
             div.custom-options
 
     div.table-body

--- a/app/styles/modules/admin/admin-custom-attributes.scss
+++ b/app/styles/modules/admin/admin-custom-attributes.scss
@@ -70,7 +70,7 @@
     }
     .custom-description {
         @include ellipsis(100%);
-        flex-basis: 90%;
+        flex-basis: 50%;
         flex-grow: 8;
     }
     .custom-field-type {

--- a/app/styles/modules/admin/admin-custom-attributes.scss
+++ b/app/styles/modules/admin/admin-custom-attributes.scss
@@ -73,6 +73,10 @@
         flex-basis: 90%;
         flex-grow: 8;
     }
+    .custom-field-type {
+        flex-basis: 25%;
+        flex-grow: 0;
+    }
     .custom-options {
         flex-basis: 100px;
         flex-grow: 0;

--- a/app/styles/modules/common/custom-fields.scss
+++ b/app/styles/modules/common/custom-fields.scss
@@ -68,11 +68,11 @@
         flex: 1;
         padding: 0 1rem 0 2rem;
         .read-mode {
-          white-space: pre
+            white-space: pre;
         }
     }
     .read-mode {
-      white-space: pre
+        white-space: pre;
     }
     form {
         label {

--- a/app/styles/modules/common/custom-fields.scss
+++ b/app/styles/modules/common/custom-fields.scss
@@ -67,6 +67,12 @@
     .custom-field-value {
         flex: 1;
         padding: 0 1rem 0 2rem;
+        .read-mode {
+          white-space: pre
+        }
+    }
+    .read-mode {
+      white-space: pre
     }
     form {
         label {


### PR DESCRIPTION
Provides the ability to create a custom field as a multi-line text box instead of a single-line text box.

Implemented as a dropdown choice between "Text" and "Multi-line" when creating/editing a custom field, so that new types can be added to this dropdown as they are implemented (eg. markdown, boolean, date, etc)

Points to note:

- Something I couldn't get to work with the string translations was displaying the field type options in the dropdown when creating a new custom field (line 58 of app/partials/includes/modules/admin/admin-custom-attributes.jade).  The translations work ok in the dropdown when editing an existing custom field, but it just gives "undefined" when creating a new custom field.  Any help here would be appreciated!

- There a many different ways I could have implemented the rendering of the custom field when in a user story, task, issue, etc.  but for this first pass it is still quite specific to a text box or a text area.  Maybe when new types get added, then a bit of a design decision needs to be made about how to implement rendering many different field types?

Let me know what you think!
