### PR TITLE
Added autocomplete for @mentions, USs, tasks, issues, and wikipages in MD textareas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Make burndown chart collapsible at the backlog panel.
 - Ability to choose a theme (thanks to [@astagi](https://github.com/astagi))
 - Inline viewing of image attachments (thanks to [@brettp](https://github.com/brettp)).
+- Autocomplete for usernames, user stories, tasks, issues, and wiki pages in text areas (thanks to [@brettp](https://github.com/brettp)).
 - i18n.
   - Add polish (pl) translation.
   - Add portuguese (Brazil) (pt_BR) translation.

--- a/app/styles/vendor/jquery.textcomplete.css
+++ b/app/styles/vendor/jquery.textcomplete.css
@@ -17,10 +17,12 @@
 .dropdown-menu li:hover,
 .dropdown-menu .active {
     background-color: rgb(110, 183, 219);
+    color: white;
 }
 
-.textcomplete-wrapper {
-    width: 100%;
+.dropdown-menu .active > a,
+.dropdown-menu .active > a:hover {
+    color: white;
 }
 
 /* SHOULD not modify */

--- a/bower.json
+++ b/bower.json
@@ -62,7 +62,7 @@
     "google-diff-match-patch-js": "~1.0.0",
     "underscore.string": "~2.3.3",
     "markitup-1x": "~1.1.14",
-    "jquery-textcomplete": "yuku-t/jquery-textcomplete#~0.1.1",
+    "jquery-textcomplete": "yuku-t/jquery-textcomplete#~0.7",
     "flot-orderBars": "emmerich/flot-orderBars",
     "flot-axislabels": "markrcote/flot-axislabels",
     "flot.tooltip": "~0.8.4",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,7 @@ paths.libs = [
     paths.vendor + "jquery-flot/jquery.flot.time.js",
     paths.vendor + "flot-axislabels/jquery.flot.axislabels.js",
     paths.vendor + "flot.tooltip/js/jquery.flot.tooltip.js",
-    paths.vendor + "jquery-textcomplete/jquery.textcomplete.js",
+    paths.vendor + "jquery-textcomplete/dist/jquery.textcomplete.js",
     paths.vendor + "markitup-1x/markitup/jquery.markitup.js",
     paths.vendor + "malihu-custom-scrollbar-plugin/jquery.mCustomScrollbar.concat.min.js",
     paths.vendor + "raven-js/dist/raven.js",


### PR DESCRIPTION
I wired up jQuery textcomplete to the MarkItUp text areas. You can complete usernames with `@`; and user stories, tasks, and issues with `#`; and wikipages with `[[`.