### PR TITLE
Adding Date field type to custom fields

### DIFF
--- a/app/coffee/modules/common/custom-field-values.coffee
+++ b/app/coffee/modules/common/custom-field-values.coffee
@@ -148,6 +148,20 @@ CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
 
             $el.html(html)
 
+            if attributeValue.field_type == "DATE"
+
+              selectedDate = null
+
+              $el.picker = new Pikaday(
+                field: $el.find('input')[0]
+                onSelect: (date) =>
+                      selectedDate = date
+                onOpen: =>
+                    $el.picker.setDate(selectedDate) if selectedDate?
+                firstDay: 1
+                format: 'DD MMM YYYY'
+                )
+
         isEditable = ->
             permissions = $scope.project.my_permissions
             requiredEditionPerm = $attrs.requiredEditionPerm
@@ -155,6 +169,9 @@ CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
 
         saveAttributeValue = ->
             attributeValue.value = $el.find("input, textarea").val()
+
+            if attributeValue.field_type == "DATE" and attributeValue.value != ''
+                return if moment(attributeValue.value).isValid() != true
 
             $scope.$apply ->
                 $ctrl.updateAttributeValue(attributeValue).then ->
@@ -164,7 +181,9 @@ CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
             if event.keyCode == 13 and event.currentTarget.type != "textarea"
                 submit(event)
             else if event.keyCode == 27
-                render(attributeValue, false)
+              return if attributeValue.field_type == "DATE" and moment(attributeValue.value).isValid() != true
+
+              render(attributeValue, false)
 
         ## Actions (on view mode)
         $el.on "click", ".custom-field-value.read-mode", ->

--- a/app/coffee/modules/common/custom-field-values.coffee
+++ b/app/coffee/modules/common/custom-field-values.coffee
@@ -118,10 +118,10 @@ CustomAttributesValuesDirective = ($templates, $storage) ->
         template: templateFn
     }
 
-module.directive("tgCustomAttributesValues", ["$tgTemplate", "$tgStorage", CustomAttributesValuesDirective])
+module.directive("tgCustomAttributesValues", ["$tgTemplate", "$tgStorage", "$translate", CustomAttributesValuesDirective])
 
 
-CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
+CustomAttributeValueDirective = ($template, $selectedText, $compile, $translate) ->
     template = $template.get("custom-attributes/custom-attribute-value.html", true)
     templateEdit = $template.get("custom-attributes/custom-attribute-value-edit.html", true)
 
@@ -158,9 +158,40 @@ CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
                       selectedDate = date
                 onOpen: =>
                     $el.picker.setDate(selectedDate) if selectedDate?
-                firstDay: 1
-                format: 'DD MMM YYYY'
-                )
+                i18n: {
+                    previousMonth: $translate.instant("COMMON.PICKERDATE.PREV_MONTH"),
+                    nextMonth:  $translate.instant("COMMON.PICKERDATE.NEXT_MONTH"),
+                    months: [$translate.instant("COMMON.PICKERDATE.MONTHS.JAN"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.FEB"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.MAR"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.APR"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.MAY"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.JUN"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.JUL"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.AUG"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.SEP"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.OCT"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.NOV"),
+                             $translate.instant("COMMON.PICKERDATE.MONTHS.DEC")],
+                    weekdays: [$translate.instant("COMMON.PICKERDATE.WEEK_DAYS.SUN"),
+                               $translate.instant("COMMON.PICKERDATE.WEEK_DAYS.MON"),
+                               $translate.instant("COMMON.PICKERDATE.WEEK_DAYS.TUE"),
+                               $translate.instant("COMMON.PICKERDATE.WEEK_DAYS.WED"),
+                               $translate.instant("COMMON.PICKERDATE.WEEK_DAYS.THU"),
+                               $translate.instant("COMMON.PICKERDATE.WEEK_DAYS.FRI"),
+                               $translate.instant("COMMON.PICKERDATE.WEEK_DAYS.SAT")],
+                    weekdaysShort: [$translate.instant("COMMON.PICKERDATE.WEEK_DAYS_SHORT.SUN"),
+                                    $translate.instant("COMMON.PICKERDATE.WEEK_DAYS_SHORT.MON"),
+                                    $translate.instant("COMMON.PICKERDATE.WEEK_DAYS_SHORT.TUE"),
+                                    $translate.instant("COMMON.PICKERDATE.WEEK_DAYS_SHORT.WED"),
+                                    $translate.instant("COMMON.PICKERDATE.WEEK_DAYS_SHORT.THU"),
+                                    $translate.instant("COMMON.PICKERDATE.WEEK_DAYS_SHORT.FRI"),
+                                    $translate.instant("COMMON.PICKERDATE.WEEK_DAYS_SHORT.SAT")]
+                },
+                isRTL: $translate.instant("COMMON.PICKERDATE.IS_RTL") == "true",
+                firstDay: parseInt($translate.instant("COMMON.PICKERDATE.FIRST_DAY_OF_WEEK"), 10),
+                format: $translate.instant("COMMON.PICKERDATE.FORMAT")
+              )
 
         isEditable = ->
             permissions = $scope.project.my_permissions
@@ -218,4 +249,4 @@ CustomAttributeValueDirective = ($template, $selectedText, $compile) ->
         restrict: "AE"
     }
 
-module.directive("tgCustomAttributeValue", ["$tgTemplate", "$selectedText", "$compile", CustomAttributeValueDirective])
+module.directive("tgCustomAttributeValue", ["$tgTemplate", "$selectedText", "$compile", "$translate", CustomAttributeValueDirective])

--- a/app/locales/locale-en.json
+++ b/app/locales/locale-en.json
@@ -456,7 +456,8 @@
             "ISSUE_DESCRIPTION": "Issues custom fields",
             "ISSUE_ADD": "Add a custom field in issues",
             "FIELD_TYPE_TEXT": "Text",
-            "FIELD_TYPE_MULTI": "Multi-line"
+            "FIELD_TYPE_MULTI": "Multi-line",
+            "FIELD_TYPE_DATE": "Date"
         },
         "PROJECT_VALUES": {
             "PAGE_TITLE": "{{sectionName}} - Project values - {{projectName}}",

--- a/app/partials/custom-attributes/custom-attribute-value-edit.jade
+++ b/app/partials/custom-attributes/custom-attribute-value-edit.jade
@@ -8,7 +8,7 @@ form.custom-field-single.editable
         <% } %>
 
     div.custom-field-value
-        
+
         <% if (field_type=="MULTI") { %>
         textarea#custom-field-description(name="description")
             <%- value %>
@@ -16,6 +16,14 @@ form.custom-field-single.editable
 
         <% if (field_type=="TEXT") { %>
         input#custom-field-description(name="description", type="text", value!="<%- value %>")
+        <% } %>
+
+        <% if (field_type=="DATE" && value!="") { %>
+        input#custom-field-description(name="description", type="text", value!="<%- moment(value).format('DD MMM YYYY') %>")
+        <% } %>
+
+        <% if (field_type=="DATE" && value=="") { %>
+        input#custom-field-description(name="description", type="text", value!="")
         <% } %>
 
     div.custom-field-options

--- a/app/partials/includes/modules/admin/admin-custom-attributes.jade
+++ b/app/partials/includes/modules/admin/admin-custom-attributes.jade
@@ -40,7 +40,7 @@ section.custom-fields-table.basic-table
                                   ng-model="attr.description")
                         fieldset.custom-field-type
                             select(ng-model="attr.field_type",
-                                ng-options="e.id as e.name | translate for e in [{'id':'TEXT', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_TEXT'},{'id':'MULTI', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_MULTI'}]")
+                                ng-options="e.id as e.name | translate for e in [{'id':'TEXT', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_TEXT'},{'id':'MULTI', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_MULTI'},{'id':'DATE', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_DATE'}]")
                         fieldset.custom-options
                             div.custom-options-wrapper
                                 a.js-update-custom-field-button.icon.icon-floppy(href="", title="{{'ADMIN.CUSTOM_ATTRIBUTES.ACTION_UPDATE' | translate}}")
@@ -55,7 +55,7 @@ section.custom-fields-table.basic-table
                       ng-model="newAttr.description")
             fieldset.custom-field-type
                 select(ng-model="newAttr.field_type",
-                      ng-options="e.id as e.name | translate for e in [{'id':'TEXT', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_TEXT'},{'id':'MULTI', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_MULTI'}]")
+                      ng-options="e.id as e.name | translate for e in [{'id':'TEXT', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_TEXT'},{'id':'MULTI', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_MULTI'},{'id':'DATE', 'name': 'ADMIN.CUSTOM_FIELDS.FIELD_TYPE_DATE'}]")
 
             fieldset.custom-options
                 div.custom-options-wrapper


### PR DESCRIPTION
This PR adds the ability to create a Date custom field.

It uses Pikaday for the data selector and validation, which I see was already in use for other date fields.
It also allows for an empty date to be saved in the case where the user might want to clear the date field.

Current date validation is performed with the date format DD MMM YYYY (eg. 01 Sep 2015), which is the same as the New Sprint popup window for start and end dates

 - Are other date formats required to be supported?
 - The code blocks the user from saving an invalid date, but there is no message to inform them that the date they've entered is actually invalid, eg. "Please enter a valid date".  I wasn't sure how best to do this so if you think this is necessary then I would appreciate some advice!

Also, this PR does not cover server-side validation at the API level but I hope to work on that on taiga-back soon.

Let me know what you think!