### PR TITLE
Issue/3359/custom field ui

### DIFF
--- a/app/partials/custom-attributes/custom-attribute-value.jade
+++ b/app/partials/custom-attributes/custom-attribute-value.jade
@@ -7,7 +7,7 @@ div.custom-field-single
             <%- description %>
         <% } %>
 
-    div.custom-field-value.read-mode
+    div.custom-field-value
         span
             <%- value %>
 

--- a/app/styles/modules/common/custom-fields.scss
+++ b/app/styles/modules/common/custom-fields.scss
@@ -51,12 +51,12 @@
         flex: 0;
         flex-basis: 200px;
         .custom-field-name {
-            @extend %bold;
             display: block;
         }
         .custom-field-description {
             @extend %small;
-            color: $gray-light;
+            @extend %light;
+            color: lighten($gray, 20%);
             display: block;
             line-height: .9rem;
         }
@@ -65,14 +65,10 @@
         margin: 0;
     }
     .custom-field-value {
+        @extend %light;
         flex: 1;
         padding: 0 1rem 0 2rem;
-        .read-mode {
-            white-space: pre;
-        }
-    }
-    .read-mode {
-        white-space: pre;
+        white-space: pre-line;
     }
     form {
         label {

--- a/e2e/utils/detail.js
+++ b/e2e/utils/detail.js
@@ -250,7 +250,7 @@ helper.customFields = function(typeIndex) {
         // debounce
         await browser.sleep(2000);
 
-        let fieldText = textField.$('.read-mode span').getText();
+        let fieldText = textField.$('.custom-field-value span').getText();
 
         expect(fieldText).to.be.eventually.equal('test text');
     });
@@ -269,7 +269,7 @@ helper.customFields = function(typeIndex) {
         // debounce
         await browser.sleep(2000);
 
-        let fieldText = textField.$('.read-mode span').getText();
+        let fieldText = textField.$('.custom-field-value span').getText();
 
         expect(fieldText).to.be.eventually.equal('test text edit');
     });
@@ -286,7 +286,7 @@ helper.customFields = function(typeIndex) {
         // debounce
         await browser.sleep(2000);
 
-        let fieldText = textField.$('.read-mode span').getText();
+        let fieldText = textField.$('.custom-field-value span').getText();
 
         expect(fieldText).to.be.eventually.equal('test text2');
     });
@@ -303,7 +303,7 @@ helper.customFields = function(typeIndex) {
 
         // // debounce
         await browser.sleep(2000);
-        let fieldText = await textField.$('.read-mode span').getText();
+        let fieldText = await textField.$('.custom-field-value span').getText();
 
         expect(fieldText).to.be.equal('test text2 edit');
     });


### PR DESCRIPTION
How to test it:

- [x] Long texts on textareas are not hidden on a single line and does not broke the UI.
- [x] Date fields are shown correctly on edition
- [x] Textfields are closed on press ESC and changes are not saved.

Taiga Issue is: https://tree.taiga.io/project/taiga/issue/3359