### PR TITLE
add timeline fields after parse and filter the api response

### DIFF
--- a/app/modules/user-timeline/user-timeline-pagination-sequence/user-timeline-pagination-sequence.service.coffee
+++ b/app/modules/user-timeline/user-timeline-pagination-sequence/user-timeline-pagination-sequence.service.coffee
@@ -18,7 +18,10 @@ UserTimelinePaginationSequence = () ->
                 data = response.get("data")
 
                 if config.filter
-                    data = config.filter(response.get("data"))
+                    data = config.filter(data)
+
+                if config.map
+                    data = data.map(config.map)
 
                 items = items.concat(data)
 

--- a/app/modules/user-timeline/user-timeline-pagination-sequence/user-timeline-pagination-sequence.service.spec.coffee
+++ b/app/modules/user-timeline/user-timeline-pagination-sequence/user-timeline-pagination-sequence.service.spec.coffee
@@ -107,3 +107,31 @@ describe "tgUserTimelinePaginationSequenceService", ->
                 expect(result.next).to.be.true
 
                 done()
+
+
+    it "map items", (done) ->
+        config = {}
+
+        page1 = Immutable.Map({
+            next: false,
+            data: [1, 2, 3]
+        })
+
+        promise = sinon.stub()
+        promise.withArgs(1).promise().resolve(page1)
+
+        config.fetch = (page) ->
+            return promise(page)
+
+        config.minItems = 1
+
+        config.map = (item) => item + 1;
+
+        seq = userTimelinePaginationSequenceService.generate(config)
+
+        seq.next().then (result) ->
+            result = result.toJS()
+
+            expect(result.items).to.be.eql([2, 3, 4])
+
+            done()

--- a/app/modules/user-timeline/user-timeline/user-timeline.service.spec.coffee
+++ b/app/modules/user-timeline/user-timeline/user-timeline.service.spec.coffee
@@ -237,32 +237,29 @@ describe "tgUserTimelineService", ->
 
     it "all timeline extra fields filled", () ->
         timeline =  Immutable.fromJS({
-            data: [{
-                event_type: 'issues.issue.created',
-                data: {
-                    user: 'user_fake',
-                    project: 'project_fake',
-                    milestone: 'milestone_fake',
-                    created: new Date().getTime(),
-                    issue: {
-                        id: 2
-                    },
-                    value_diff: {
-                        key: 'attachments',
-                        value: {
-                            new: "fakeAttachment"
-                        }
+            event_type: 'issues.issue.created',
+            data: {
+                user: 'user_fake',
+                project: 'project_fake',
+                milestone: 'milestone_fake',
+                created: new Date().getTime(),
+                issue: {
+                    id: 2
+                },
+                value_diff: {
+                    key: 'attachments',
+                    value: {
+                        new: "fakeAttachment"
                     }
                 }
-            }]
+            }
         })
 
         mocks.userTimelineItemTitle.getTitle.returns("fakeTitle")
         mocks.getType.description.returns("fakeDescription")
         mocks.getType.member.returns("fakeMember")
 
-        timeline = userTimelineService._parseTimeline(timeline)
-        timelineEntry = timeline.get('data').get(0)
+        timelineEntry = userTimelineService._addEntyAttributes(timeline)
 
         expect(timelineEntry.get('title_html')).to.be.equal("fakeTitle")
         expect(timelineEntry.get('obj')).to.be.equal(timelineEntry.getIn(["data", "issue"]))


### PR DESCRIPTION
apply the extra fields in an array without filter it fails in some cases (for example, project change)