### PR TITLE
TG-3344 Comment is edited if you cancel add link dialog

### DIFF
--- a/app/coffee/modules/common/wisiwyg.coffee
+++ b/app/coffee/modules/common/wisiwyg.coffee
@@ -149,6 +149,8 @@ MarkitupDirective = ($rootscope, $rs, $selectedText, $template, $compile, $trans
                     startIndex = result.index
                     break
 
+            return if !result
+
             regex = />>>/gi
             endIndex = 0
             loop


### PR DESCRIPTION
When dialog is canceled, the result will be null because there is no start of link "<<<" inserted. In this case we shouldn't search for the end of the link and just return.