### PR TITLE
Protractor's Selenium Server depends on Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ And go in your browser to: http://localhost:9001/
 If you want to run e2e tests
 
 ```
+apt-get install -y openjdk-7-jre-headless
 npm install -g protractor
 npm install -g mocha
 npm install -g babel


### PR DESCRIPTION
If Java isn't installed, it throws the following error:

    daniel@daniel-VirtualBox:~/taiga-front$ webdriver-manager start
    seleniumProcess.pid: undefined
    events.js:141
          throw er; // Unhandled 'error' event
          ^

    Error: spawn java ENOENT
        at exports._errnoException (util.js:874:11)
        at Process.ChildProcess._handle.onexit (internal/child_process.js:178:32)
        at onErrorNT (internal/child_process.js:344:16)
        at doNTCallback2 (node.js:441:9)
        at process._tickCallback (node.js:355:17)
        at Function.Module.runMain (module.js:469:11)
        at startup (node.js:136:18)
        at node.js:963:3