### PR TITLE
Update lodash to 3.10.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "tests"
   ],
   "dependencies": {
-    "lodash": "~2.4.2",
+    "lodash": "~3.10.1",
     "emoticons": "~0.1.7",
     "jquery-flot": "~0.8.2",
     "angular": "1.4.7",
@@ -85,7 +85,7 @@
     "intro.js": "~1.1.1"
   },
   "resolutions": {
-    "lodash": "~2.4.2",
+    "lodash": "~3.10.1",
     "moment": "~2.10.6",
     "jquery": "~2.1.1",
     "angular": "1.4.7"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -138,7 +138,7 @@ paths.coffee_order = [
 paths.libs = [
     paths.vendor + "bluebird/js/browser/bluebird.js",
     paths.vendor + "jquery/dist/jquery.js",
-    paths.vendor + "lodash/dist/lodash.js",
+    paths.vendor + "lodash/lodash.js",
     paths.vendor + "emoticons/lib/emoticons.js",
     paths.vendor + "underscore.string/lib/underscore.string.js",
     paths.vendor + "messageformat/messageformat.js",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
       'vendor/bluebird/js/browser/bluebird.js',
       'node_modules/chai-jquery/chai-jquery.js',
       'node_modules/chai-jquery/chai-jquery.js',
-      'vendor/lodash/dist/lodash.js',
+      'vendor/lodash/lodash.js',
       'vendor/underscore.string/lib/underscore.string.js',
       'test-utils.js',
       'dist/js/app.js',


### PR DESCRIPTION
As requested on https://tree.taiga.io/project/taiga/issue/3327, I went and updated Lodash (I'm not able to comment on that issue with my Taiga account though).

All unit tests passed. However, I have not been able to run the e2e tests on my computer. But it looked fine when I browsed around locally.

A problem/annoyance though is that Checksley has a dependency on lodash#~2.2.1, which comes apparent when running `$ bower install`:

    Unable to find a suitable version for lodash, please choose one:
        1) lodash#~2.2.1 which resolved to 2.2.1 and is required by checksley#0.6.0
        2) lodash#~3.10.1 which resolved to 3.10.1 and is required by taiga-layout

Checksley's last release (0.6.0) was in [August 2014](https://github.com/jespino/checksley/releases), so I doubt it will be updated.

Furthermore, a bit unrelated, Checksley's jQuery dependency also resolves to an older release:

    Please note that,
        checksley#0.6.0 depends on jquery#~1.10.0 which resolved to jquery#1.10.2
        jquery-textcomplete#0.7.3 depends on jquery#>=1.7.0 which resolved to jquery#2.1.4
        jquery-flot#0.8.3 depends on jquery#>= 1.2.6 which resolved to jquery#2.1.4
        angular-ui-select2#0.0.5 depends on jquery#>=1.6.4 which resolved to jquery#2.1.4
        taiga-layout depends on jquery#~2.1.1 which resolved to jquery#2.1.4
        select2#3.4.8 depends on jquery#>= 1.7.1 which resolved to jquery#2.1.4
        malihu-custom-scrollbar-plugin#3.1.1 depends on jquery#>=1.6 which resolved to jquery#2.1.4
        jquery-mousewheel#3.1.13 depends on jquery#>=1.2.2 which resolved to jquery#2.1.4
    Resort to using jquery#~2.1.1 which resolved to jquery#2.1.4
    Code incompatibilities may occur.

