### PR TITLE
e2e tests only work with Babel 5 (not 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you want to run e2e tests
 ```
 npm install -g protractor
 npm install -g mocha
-npm install -g babel
+npm install -g babel@5
 
 webdriver-manager update
 ```


### PR DESCRIPTION
Explicitly set the version of Babel to 5.

Source: https://groups.google.com/d/msg/taigaio/kp2cofaI_rI/6mVNTpOxBAAJ