### PR TITLE
fixed issue#2619 and #1951

### DIFF
--- a/app/coffee/modules/common/components.coffee
+++ b/app/coffee/modules/common/components.coffee
@@ -675,12 +675,30 @@ ListItemIssueStatusDirective = ->
 
 module.directive("tgListitemIssueStatus", ListItemIssueStatusDirective)
 
+#Function to get the color easiest to distinguish from the background color
+InvertColor = (typeColor)->
+    invert=typeColor
+    for color in typeColor.toUpperCase()
+        switch color
+            when '#' then invert="#"
+            when '0' then invert+='F'
+            when '1' then invert+='F'
+            when '2' then invert+='F'
+            when '3' then invert+='F'
+            when '4' then invert+='F'
+            when '5' then invert+='F'
+            when '6' then invert+='F'
+            when '7' then invert+='F'
+            else invert+='0'
+    return invert
 
 ListItemTypeDirective = ->
     link = ($scope, $el, $attrs) ->
         render = (issueTypeById, issue) ->
             type = issueTypeById[issue.type]
             domNode = $el.find(".level")
+            domNode.html(type.name[0])
+            domNode.css("color", InvertColor(type.color))
             domNode.css("background-color", type.color)
             domNode.attr("title", type.name)
 
@@ -704,6 +722,8 @@ ListItemPriorityDirective = ->
         render = (priorityById, issue) ->
             priority = priorityById[issue.priority]
             domNode = $el.find(".level")
+            domNode.html(priority.name[0])
+            domNode.css("color", InvertColor(priority.color))
             domNode.css("background-color", priority.color)
             domNode.attr("title", priority.name)
 
@@ -727,6 +747,8 @@ ListItemSeverityDirective = ->
         render = (severityById, issue) ->
             severity = severityById[issue.severity]
             domNode = $el.find(".level")
+            domNode.html(severity.name[0])
+            domNode.css("color", InvertColor(severity.color))
             domNode.css("background-color", severity.color)
             domNode.attr("title", severity.name)
 

--- a/app/locales/locale-ca.json
+++ b/app/locales/locale-ca.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "tasques<br />tancades",
             "IOCAINE_DOSES": "dosis<br />iocaína",
             "SHOW_STATISTICS_TITLE": "Mostrar estadístiques",
-            "TOGGLE_BAKLOG_GRAPH": "Show/Hide burndown graph"
+            "TOGGLE_BAKLOG_GRAPH": "Show/Hide burndown graph",
+            "PRINT_SPRINT": "Esprint d'impressió"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "punts<br/> projecte",

--- a/app/locales/locale-de.json
+++ b/app/locales/locale-de.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "geschlossene<br />Aufgaben",
             "IOCAINE_DOSES": "Iocaine<br />Dosen",
             "SHOW_STATISTICS_TITLE": "Statistik anzeigen",
-            "TOGGLE_BAKLOG_GRAPH": "Zeige/Verstecke Burndowngraph"
+            "TOGGLE_BAKLOG_GRAPH": "Zeige/Verstecke Burndowngraph",
+            "PRINT_SPRINT": "Sprint drucken"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "Projekt<br />Punkte",

--- a/app/locales/locale-en.json
+++ b/app/locales/locale-en.json
@@ -992,7 +992,8 @@
             "CLOSED_TASKS": "closed<br />tasks",
             "IOCAINE_DOSES": "iocaine<br />doses",
             "SHOW_STATISTICS_TITLE": "Show statistics",
-            "TOGGLE_BAKLOG_GRAPH": "Show/Hide burndown graph"
+            "TOGGLE_BAKLOG_GRAPH": "Show/Hide burndown graph",
+            "PRINT_SPRINT": "Print sprint"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "project<br />points",

--- a/app/locales/locale-es.json
+++ b/app/locales/locale-es.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "tareas<br />cerradas",
             "IOCAINE_DOSES": "dosis de<br >iocaína",
             "SHOW_STATISTICS_TITLE": "Ver estadísticas",
-            "TOGGLE_BAKLOG_GRAPH": "Ver/Ocultar gráfica de burndown"
+            "TOGGLE_BAKLOG_GRAPH": "Ver/Ocultar gráfica de burndown",
+            "PRINT_SPRINT": "Sprint de impresión "
         },
         "SUMMARY": {
             "PROJECT_POINTS": "puntos<br /> proyecto",

--- a/app/locales/locale-fi.json
+++ b/app/locales/locale-fi.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "suljettu<br/>tehtävää",
             "IOCAINE_DOSES": "myrkkye-<br/>annosta",
             "SHOW_STATISTICS_TITLE": "Näytä tilastot",
-            "TOGGLE_BAKLOG_GRAPH": "Show/Hide burndown graph"
+            "TOGGLE_BAKLOG_GRAPH": "Show/Hide burndown graph",
+            "PRINT_SPRINT": "Kirjoittaa kierroksia"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "projekti<br/>pistettä",

--- a/app/locales/locale-fr.json
+++ b/app/locales/locale-fr.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "tâches<br />fermées",
             "IOCAINE_DOSES": "doses<br />de iocaine",
             "SHOW_STATISTICS_TITLE": "Afficher les statistiques",
-            "TOGGLE_BAKLOG_GRAPH": "Afficher/masquer le graphique d'avancement"
+            "TOGGLE_BAKLOG_GRAPH": "Afficher/masquer le graphique d'avancement",
+            "PRINT_SPRINT": "Imprimer sprint"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "projet<br />points",

--- a/app/locales/locale-it.json
+++ b/app/locales/locale-it.json
@@ -990,7 +990,7 @@
             "IOCAINE_DOSES": "<br /> pasticche di aspirina",
             "SHOW_STATISTICS_TITLE": "Mostra statistiche",
             "TOGGLE_BAKLOG_GRAPH": "Mostra/nascondi i grafici burndown",
-            "PRINT_SPRINT": "stampa sprint"
+            "PRINT_SPRINT": "Stampa sprint"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "<br /> punti di progetto",

--- a/app/locales/locale-it.json
+++ b/app/locales/locale-it.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "<br /> compiti chiusi",
             "IOCAINE_DOSES": "<br /> pasticche di aspirina",
             "SHOW_STATISTICS_TITLE": "Mostra statistiche",
-            "TOGGLE_BAKLOG_GRAPH": "Mostra/nascondi i grafici burndown"
+            "TOGGLE_BAKLOG_GRAPH": "Mostra/nascondi i grafici burndown",
+            "PRINT_SPRINT": "stampa sprint"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "<br /> punti di progetto",

--- a/app/locales/locale-nl.json
+++ b/app/locales/locale-nl.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "gesloten<br/>taken",
             "IOCAINE_DOSES": "iocaine<br />dosissen",
             "SHOW_STATISTICS_TITLE": "Toon statistieken",
-            "TOGGLE_BAKLOG_GRAPH": "Toon/Verstop burndown grafiek"
+            "TOGGLE_BAKLOG_GRAPH": "Toon/Verstop burndown grafiek",
+            "PRINT_SPRINT": "Afdruk sprint"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "project<br/>punten",

--- a/app/locales/locale-pl.json
+++ b/app/locales/locale-pl.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "zamkniętych<br />zadań",
             "IOCAINE_DOSES": "dawek<br />Iokainy",
             "SHOW_STATISTICS_TITLE": "Pokaż statystyki",
-            "TOGGLE_BAKLOG_GRAPH": "Pokaż/Ukryj wykres spalania"
+            "TOGGLE_BAKLOG_GRAPH": "Pokaż/Ukryj wykres spalania",
+            "PRINT_SPRINT": "Drukuj sprintu"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "punktów w<br />projekcie",

--- a/app/locales/locale-pt-br.json
+++ b/app/locales/locale-pt-br.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "tarefas<br />fechadas",
             "IOCAINE_DOSES": "iocaine<br />doses",
             "SHOW_STATISTICS_TITLE": "Mostrar estatísticas",
-            "TOGGLE_BAKLOG_GRAPH": "Mostrar/Esconder gráfico burndown"
+            "TOGGLE_BAKLOG_GRAPH": "Mostrar/Esconder gráfico burndown",
+            "PRINT_SPRINT": "Impressão de sprint"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "pontos do<br />projeto",

--- a/app/locales/locale-ru.json
+++ b/app/locales/locale-ru.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "завершённые <br /> задачи",
             "IOCAINE_DOSES": "иокаина<br />дозы",
             "SHOW_STATISTICS_TITLE": "Показать статистику",
-            "TOGGLE_BAKLOG_GRAPH": "Показать/Скрыть график решения задач"
+            "TOGGLE_BAKLOG_GRAPH": "Показать/Скрыть график решения задач",
+            "PRINT_SPRINT": "Печать спринт"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "проектные<br />очки",

--- a/app/locales/locale-zh-hant.json
+++ b/app/locales/locale-zh-hant.json
@@ -989,7 +989,8 @@
             "CLOSED_TASKS": "已關閉<br />任務",
             "IOCAINE_DOSES": "毒物（全新任務挑戰）<br />劑量",
             "SHOW_STATISTICS_TITLE": "顯示統計",
-            "TOGGLE_BAKLOG_GRAPH": "顯示/隱藏 剩餘工作量圖"
+            "TOGGLE_BAKLOG_GRAPH": "顯示/隱藏 剩餘工作量圖",
+            "PRINT_SPRINT": "打印衝刺"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "專案<br/> 點數",

--- a/app/partials/includes/modules/taskboard-table.jade
+++ b/app/partials/includes/modules/taskboard-table.jade
@@ -1,4 +1,4 @@
-div.taskboard-table(tg-taskboard-squish-column)
+div#taskboardt.taskboard-table(tg-taskboard-squish-column)
     div.taskboard-table-header
         div.taskboard-table-inner
             h2.task-colum-name(translate="TASKBOARD.TABLE.COLUMN")

--- a/app/partials/taskboard/taskboard.jade
+++ b/app/partials/taskboard/taskboard.jade
@@ -16,7 +16,8 @@ div.wrapper(tg-taskboard, ng-controller="TaskboardController as ctrl",
                     include ../includes/modules/burndown
 
             include ../includes/modules/taskboard-table
-
+        div(style="margin-top:5px; text-align:right")
+            a.printtable(href="", onClick="var bodyhtml=document.body.innerHTML; document.body.innerHTML = document.getElementById('taskboardt').innerHTML; window.print(); document.body.innerHTML = bodyhtml;") {{'BACKLOG.SPRINT_SUMMARY.PRINT_SPRINT' | translate}}
     div.lightbox.lightbox-generic-form(tg-lb-create-edit-task)
         include ../includes/modules/lightbox-task-create-edit
 

--- a/app/styles/components/level.scss
+++ b/app/styles/components/level.scss
@@ -1,7 +1,12 @@
 .level {
     background-color: $gray-light;
     border-radius: 9px;
+    color: $white;
+    font-size: 12px;
+    font-weight: bold;
     height: 18px;
     margin: 0 auto;
+    padding-top: 1px;
+    text-align: center;
     width: 18px;
 }

--- a/app/styles/layout/taskboard.scss
+++ b/app/styles/layout/taskboard.scss
@@ -14,6 +14,6 @@
 .taskboard-inner {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    height: 96%;
     overflow: hidden;
 }


### PR DESCRIPTION
Hi, 
I fixed the issue
*#1951 Easy hardcopy in emergency situations* by adding a button under taskboard-table to allow user print the taskboard-table of the sprint
and 
*#2619 Colorblind alternative (issues table)* by add the first letter of the name of type/ priority/ severity and use a most easy to distinguish color.

However, the improvement for #2619 is not perfect. We did a user test on that, all users tested gave a positive answer, but some users also provided some suggestion. We will send you an email about the details.