### PR TITLE
Copy contrib plugins to version-based folder

### DIFF
--- a/app-loader/app-loader.coffee
+++ b/app-loader/app-loader.coffee
@@ -22,7 +22,7 @@ promise.done (data) ->
 
 promise.always ->
     if window.taigaConfig.contribPlugins.length > 0
-        plugins = _.map(window.taigaConfig.contribPlugins, (plugin) -> "#{plugin}")
+        plugins = _.map(window.taigaConfig.contribPlugins, (plugin) -> "/#{window._version}/#{plugin}")
         ljs.load plugins, ->
             ljs.load "/#{window._version}/js/app.js", ->
                 angular.bootstrap(document, ['taiga'])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -496,6 +496,11 @@ gulp.task("copy-images-plugins", function() {
         .pipe(gulp.dest(paths.distVersion + "/images/"));
 });
 
+gulp.task("copy-plugins-dist", function() {
+    return gulp.src(paths.dist + "/js/*")
+        .pipe(gulp.dest(paths.distVersion + "/js/"));
+});
+
 gulp.task("copy-plugin-templates", function() {
     return gulp.src(paths.app + "/plugins/**/templates/**/*.html")
         .pipe(gulp.dest(paths.distVersion + "/plugins/"));
@@ -512,6 +517,7 @@ gulp.task("copy", [
     "copy-images",
     "copy-theme-images",
     "copy-images-plugins",
+    "copy-plugins-dist",
     "copy-plugin-templates",
     "copy-svg",
     "copy-theme-svg",


### PR DESCRIPTION
Hi!

I couldn't get my plugin (taiga-contrib-dropbox) to work with the version-based folder. I even tried to install [taiga-contrib-gogs](https://github.com/taigaio/taiga-contrib-gogs) with no success. I am proposing to copy contrib plugins from the dist/js to the version-based folder to address this problem.

Let me know what you think.

Regards,
Alexander