### PR TITLE
feat - Added assign to me button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## 1.10.0 ??? (unreleased)
 - [118n] Now taiga plugins can be translatable.
+- Added 'Assign to me' button in User Stories and Issues
 
 ### Misc
 - Statics folder hash to prevent cache problems when a new version is released.

--- a/app/coffee/modules/common/components.coffee
+++ b/app/coffee/modules/common/components.coffee
@@ -263,7 +263,7 @@ module.directive("tgWatchers", ["$rootScope", "$tgConfirm", "$tgRepo", "$tgQqueu
 ## Assigned to directive
 #############################################################################
 
-AssignedToDirective = ($rootscope, $confirm, $repo, $loading, $qqueue, $template, $translate, $compile) ->
+AssignedToDirective = ($rootscope, $confirm, $repo, $loading, $qqueue, $template, $translate, $compile, $currentUserService) ->
     # You have to include a div with the tg-lb-assignedto directive in the page
     # where use this directive
     template = $template.get("common/components/assigned-to.html", true)
@@ -309,6 +309,12 @@ AssignedToDirective = ($rootscope, $confirm, $repo, $loading, $qqueue, $template
             $scope.$apply ->
                 $rootscope.$broadcast("assigned-to:add", $model.$modelValue)
 
+        $el.on "click", ".assign-to-me", (event) ->
+            event.preventDefault()
+            return if not isEditable()
+            $model.$modelValue.assigned_to = $currentUserService.getUser().get('id')
+            save($currentUserService.getUser().get('id'))
+
         $el.on "click", ".icon-delete", (event) ->
             event.preventDefault()
             return if not isEditable()
@@ -335,7 +341,7 @@ AssignedToDirective = ($rootscope, $confirm, $repo, $loading, $qqueue, $template
         require:"ngModel"
     }
 
-module.directive("tgAssignedTo", ["$rootScope", "$tgConfirm", "$tgRepo", "$tgLoading", "$tgQqueue", "$tgTemplate", "$translate", "$compile",
+module.directive("tgAssignedTo", ["$rootScope", "$tgConfirm", "$tgRepo", "$tgLoading", "$tgQqueue", "$tgTemplate", "$translate", "$compile","tgCurrentUserService",
                                   AssignedToDirective])
 
 

--- a/app/locales/taiga/locale-ca.json
+++ b/app/locales/taiga/locale-ca.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Esborra assignat",
             "TOO_MANY": ".. massa usuaris, segueix filtrant",
             "CONFIRM_UNASSIGNED": "Segut que vols deixar-ho sense assignar?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Editar assignament"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Editar assignament",
+            "SELF": "Asignar a mí"
         },
         "STATUS": {
             "CLOSED": "Tancat",

--- a/app/locales/taiga/locale-de.json
+++ b/app/locales/taiga/locale-de.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Zugewiesene entfernen",
             "TOO_MANY": "...zu viele Benutzer. Filtern Sie! ",
             "CONFIRM_UNASSIGNED": "Möchten dies wirklich ohne eine Zuordnung verlassen?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Zuordnungen bearbeiten"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Zuordnungen bearbeiten",
+            "SELF": "Vergeben Sie mir"
         },
         "STATUS": {
             "CLOSED": "Geschlossen",

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Remove assigned",
             "TOO_MANY": "...too many users, keep filtering",
             "CONFIRM_UNASSIGNED": "Are you sure you want to leave it unassigned?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Edit assignment"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Edit assignment",
+            "SELF": "Assign to me"
         },
         "STATUS": {
             "CLOSED": "Closed",

--- a/app/locales/taiga/locale-es.json
+++ b/app/locales/taiga/locale-es.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Eliminar asignación",
             "TOO_MANY": "...Demasiados usuarios, continué filtrando",
             "CONFIRM_UNASSIGNED": "¿Está seguro de que desea dejarla sin asignar?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Editar asignación"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Editar asignación",
+            "SELF": "Asignar a mí"
         },
         "STATUS": {
             "CLOSED": "Cerrada",

--- a/app/locales/taiga/locale-fi.json
+++ b/app/locales/taiga/locale-fi.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Poista tekijä",
             "TOO_MANY": "...liikaa käyttäjiä, lisää suodattimia",
             "CONFIRM_UNASSIGNED": "Haluatko varmasti jättää tämän ilman tekijää?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Muokkaa tekijää"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Muokkaa tekijää",
+            "SELF": "Liitä minulle"
         },
         "STATUS": {
             "CLOSED": "Suljettu",

--- a/app/locales/taiga/locale-fr.json
+++ b/app/locales/taiga/locale-fr.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Supprimer l'affectation",
             "TOO_MANY": "...trop d'utilisateurs ; filtrez davantage",
             "CONFIRM_UNASSIGNED": "Etes-vous sûr de vouloir continuer sans affectation ?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Modifier l'affectation"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Modifier l'affectation",
+            "SELF": "Attribuer à mois"
         },
         "STATUS": {
             "CLOSED": "Fermé",

--- a/app/locales/taiga/locale-it.json
+++ b/app/locales/taiga/locale-it.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Rimuovi incaricato",
             "TOO_MANY": "...troppi utenti, continua a filtrare",
             "CONFIRM_UNASSIGNED": "Sei sicuro di volerlo lasciare non assegnato?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Modifica incarico"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Modifica incarico",
+            "SELF": "Assegna a me"
         },
         "STATUS": {
             "CLOSED": "Chiuso",

--- a/app/locales/taiga/locale-nl.json
+++ b/app/locales/taiga/locale-nl.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Verwijder toegewezene",
             "TOO_MANY": "...te veel gebruikers, blijf filteren",
             "CONFIRM_UNASSIGNED": "Weet je zeker dat je deze niet wilt toewijzen?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Toewijzing bewerken"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Toewijzing bewerken",
+            "SELF": "Toewijzen aan mij"
         },
         "STATUS": {
             "CLOSED": "Gesloten",

--- a/app/locales/taiga/locale-pl.json
+++ b/app/locales/taiga/locale-pl.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Ukryj przypisane",
             "TOO_MANY": "...zbyt wielu użytkowników, filtruj dalej Umpa Lumpy nie ogarniają",
             "CONFIRM_UNASSIGNED": "Jesteś pewny, że chcesz pozostawić nieprzypisane?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Edytuj przypisanie"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Edytuj przypisanie",
+            "SELF": "Przypisanie do mnie"
         },
         "STATUS": {
             "CLOSED": "Zamknięte",

--- a/app/locales/taiga/locale-pt-br.json
+++ b/app/locales/taiga/locale-pt-br.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Remover assinatura",
             "TOO_MANY": "...muitos usuários, continue filtrando",
             "CONFIRM_UNASSIGNED": "Você tem certeza que deseja deixar sem ",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "E"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "E",
+            "SELF": "Atribuir para mim"
         },
         "STATUS": {
             "CLOSED": "Fechado",

--- a/app/locales/taiga/locale-ru.json
+++ b/app/locales/taiga/locale-ru.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "Удалить назначение",
             "TOO_MANY": "...слишком много пользователей, продолжайте фильтровать",
             "CONFIRM_UNASSIGNED": "Вы уверены что не хотите назначить ответственного?",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "Изменить назначение"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "Изменить назначение",
+            "SELF": "Связать меня"
         },
         "STATUS": {
             "CLOSED": "Закрыт",

--- a/app/locales/taiga/locale-zh-hant.json
+++ b/app/locales/taiga/locale-zh-hant.json
@@ -143,7 +143,8 @@
             "REMOVE_ASSIGNED": "數值",
             "TOO_MANY": "太多用戶，繼續過濾中",
             "CONFIRM_UNASSIGNED": "你確定要讓它無任何指派嗎？",
-            "TITLE_ACTION_EDIT_ASSIGNMENT": "編輯指派"
+            "TITLE_ACTION_EDIT_ASSIGNMENT": "編輯指派",
+            "SELF": "分配給我"
         },
         "STATUS": {
             "CLOSED": "關閉",

--- a/app/partials/common/components/assigned-to.jade
+++ b/app/partials/common/components/assigned-to.jade
@@ -20,3 +20,11 @@
     <% if (assignedTo!==null && isEditable) { %>
     a.icon.icon-delete(href="" title="{{'COMMON.ASSIGNED_TO.DELETE_ASSIGNMENT' | translate}}")
     <% } %>
+    <% if(isEditable && !assignedTo){ %>
+    a.assign-to-me(
+        href=""
+        title="{{'COMMON.ASSIGNED_TO.SELF' | translate}}"
+    )
+        span.icon.icon-plus
+        span(translate="COMMON.ASSIGNED_TO.SELF")
+    <% }; %>

--- a/app/styles/modules/common/assigned-to.scss
+++ b/app/styles/modules/common/assigned-to.scss
@@ -49,6 +49,22 @@
             @include ellipsis(80%);
             display: inline-block;
         }
+        .assign-to-me {
+            display: block;
+            font-size: 90%;
+            margin: .5rem .5rem .5rem 0;
+            .icon {
+                background: rgba($grayer, .25);
+                color: $whitish;
+                margin-right: .5rem;
+                padding: .25rem;
+            }
+            &:hover .icon {
+                background: $primary-light;
+                color: $whitish;
+                transition: background .3s linear;
+            }
+        }
         .icon-delete {
             color: $gray-light;
             opacity: 0;


### PR DESCRIPTION
One of the most common scenarios I found while using Taiga is that I
assign User Stories or Issues to myself, looking at other tools such as
Gitlab it comes with a quick 'Assign to me' button for merge requests.

In this pull request I have added a 'Assign to me' button with the same
styling as the 'Add Watchers' button. This shows in both User Stories
and Issues.