### PR TITLE
Added role point detail below taskboard summary header

### DIFF
--- a/app/coffee/modules/taskboard/main.coffee
+++ b/app/coffee/modules/taskboard/main.coffee
@@ -145,7 +145,9 @@ class TaskboardController extends mixOf(taiga.Controller, taiga.PageMixin)
             completedPointsSum = _.reduce(_.values(stats.completed_points), ((res, n) -> res + n), 0)
             remainingPointsSum = totalPointsSum - completedPointsSum
             remainingTasks = stats.total_tasks - stats.completed_tasks
+            @scope.showPointsDetail = false
             @scope.stats = stats
+            @scope.stats.totalPoints = stats.total_points
             @scope.stats.totalPointsSum = totalPointsSum
             @scope.stats.completedPointsSum = completedPointsSum
             @scope.stats.remainingPointsSum = remainingPointsSum

--- a/app/partials/includes/components/sprint-summary.jade
+++ b/app/partials/includes/components/sprint-summary.jade
@@ -5,7 +5,7 @@ div.summary.large-summary
             div.data
                 span.number(ng-bind="stats.completedPercentage + '%'")
 
-        div.summary-stats
+        div.summary-stats(ng-click="showPointsDetail = !showPointsDetail")
             span.number(ng-bind="stats.totalPointsSum|default:'--'")
             span.description(translate="BACKLOG.SPRINT_SUMMARY.TOTAL_POINTS")
         div.summary-stats
@@ -24,6 +24,11 @@ div.summary.large-summary
             span.icon.icon-iocaine
             span.number(ng-bind="stats.iocaine_doses|default:'--'")
             span.description(translate="BACKLOG.SPRINT_SUMMARY.IOCAINE_DOSES")
-            
+
     div.stats.toggle-analytics-visibility(title="{{'BACKLOG.SPRINT_SUMMARY.SHOW_STATISTICS_TITLE' | translate}}")
         include ../../../svg/graph.svg
+
+div.summary.large-summary-wrapper.taskboard-summary-points(ng-show="showPointsDetail")
+    div.summary-stats(ng-repeat="(role, stat) in stats.totalPoints")
+        span.number(ng-bind="stat")
+        span.description {{ roleById[role].name }}

--- a/app/styles/components/summary.scss
+++ b/app/styles/components/summary.scss
@@ -150,6 +150,10 @@ $summary-background: $grayer;
     }
 }
 
+.taskboard-summary-points {
+    margin-top: -30px;
+}
+
 .empty-burndown {
     @extend %light;
     align-content: center;


### PR DESCRIPTION
- Clicking the total points `.summary-stats` element will toggle a new row with the point details by role.

This is very useful when creating sprints with a specific milestone, since here we estimate what we can do in two weeks (a full sprint) and every team member make a small presentation (10m) of what have (s)he done in that sprint. That way everyone knows what is being done with our app.

For that purpose, once we have the US estimated, we need a way to show how many points per role we are assigning to a specific sprint so we try to don't include US that are going to remain incomplete.

This PR is a test I made in about ~15min without knowledge of the code at all, I want feedback to check if this can be done/it's useful to someone else and the correct way to implement it possible.

PS. I can also go to your offices this thursday/friday if you think that'll help.

![photo_2015-12-15_09-59-31](https://cloud.githubusercontent.com/assets/812088/11806335/9e924326-a312-11e5-8281-e29e50f37a8c.jpg)
