### PR TITLE
Fix #3846: Exclude private projects in discover section

### DIFF
--- a/app/modules/discover/services/discover-projects.service.coffee
+++ b/app/modules/discover/services/discover-projects.service.coffee
@@ -25,6 +25,10 @@ class DiscoverProjectsService extends taiga.Service
         "tgProjectsService"
     ]
 
+    _discoverParams = {
+        discover_mode: true
+    }
+
     constructor: (@rs, @projectsService) ->
         @._mostLiked = Immutable.List()
         @._mostActive = Immutable.List()
@@ -42,7 +46,8 @@ class DiscoverProjectsService extends taiga.Service
         taiga.defineImmutableProperty @, "projectsCount", () => return @._projectsCount
 
     fetchMostLiked: (params) ->
-        return @rs.projects.getProjects(params, false)
+        _params = _.extend({}, _discoverParams, params)
+        return @rs.projects.getProjects(_params, false)
             .then (result) =>
                 data = result.data.slice(0, 5)
 
@@ -52,7 +57,8 @@ class DiscoverProjectsService extends taiga.Service
                 @._mostLiked = projects
 
     fetchMostActive: (params) ->
-        return @rs.projects.getProjects(params, false)
+        _params = _.extend({}, _discoverParams, params)
+        return @rs.projects.getProjects(_params, false)
             .then (result) =>
                 data = result.data.slice(0, 5)
 
@@ -62,9 +68,10 @@ class DiscoverProjectsService extends taiga.Service
                 @._mostActive = projects
 
     fetchFeatured: () ->
-        params = {is_featured: true}
+        _params = _.extend({}, _discoverParams)
+        _params.is_featured = true
 
-        return @rs.projects.getProjects(params, false)
+        return @rs.projects.getProjects(_params, false)
             .then (result) =>
                 data = result.data.slice(0, 4)
 
@@ -81,7 +88,8 @@ class DiscoverProjectsService extends taiga.Service
             @._projectsCount = discover.getIn(['projects', 'total'])
 
     fetchSearch: (params) ->
-        return @rs.projects.getProjects(params)
+        _params = _.extend({}, _discoverParams, params)
+        return @rs.projects.getProjects(_params)
             .then (result) =>
                 @._nextSearchPage = !!result.headers('X-Pagination-Next')
 

--- a/app/modules/discover/services/discover-projects.service.spec.coffee
+++ b/app/modules/discover/services/discover-projects.service.spec.coffee
@@ -62,7 +62,7 @@ describe "tgDiscoverProjectsService", ->
         _inject()
 
     it "fetch most liked", (done) ->
-        params = {test: 1}
+        params = {test: 1, discover_mode: true}
 
         mocks.resources.projects.getProjects.withArgs(sinon.match(params), false).promise().resolve({
             data: [
@@ -80,12 +80,12 @@ describe "tgDiscoverProjectsService", ->
             result = discoverProjectsService._mostLiked.toJS()
 
             expect(result).to.have.length(5)
-            expect(result[0].decorate).to.be.ok;
+            expect(result[0].decorate).to.be.ok
 
             done()
 
     it "fetch most active", (done) ->
-        params = {test: 1}
+        params = {test: 1, discover_mode: true}
 
         mocks.resources.projects.getProjects.withArgs(sinon.match(params), false).promise().resolve({
             data: [
@@ -103,12 +103,13 @@ describe "tgDiscoverProjectsService", ->
             result = discoverProjectsService._mostActive.toJS()
 
             expect(result).to.have.length(5)
-            expect(result[0].decorate).to.be.ok;
+            expect(result[0].decorate).to.be.ok
 
             done()
 
     it "fetch featured", (done) ->
-        mocks.resources.projects.getProjects.withArgs(sinon.match({is_featured: true}), false).promise().resolve({
+        params = {is_featured: true, discover_mode: true}
+        mocks.resources.projects.getProjects.withArgs(sinon.match(params), false).promise().resolve({
             data: [
                 {id: 1},
                 {id: 2},
@@ -124,7 +125,7 @@ describe "tgDiscoverProjectsService", ->
             result = discoverProjectsService._featured.toJS()
 
             expect(result).to.have.length(4)
-            expect(result[0].decorate).to.be.ok;
+            expect(result[0].decorate).to.be.ok
 
             done()
 
@@ -148,7 +149,7 @@ describe "tgDiscoverProjectsService", ->
             done()
 
     it "fetch search", (done) ->
-        params = {test: 1}
+        params = {test: 1, discover_mode: true}
 
         result = {
             headers: sinon.stub(),


### PR DESCRIPTION
Related to https://github.com/taigaio/taiga-back/pull/593