### PR TITLE
Hide related attachments and related tasks

### DIFF
--- a/app/coffee/modules/related-tasks.coffee
+++ b/app/coffee/modules/related-tasks.coffee
@@ -227,6 +227,19 @@ RelatedTasksDirective = ($repo, $rs, $rootscope) ->
                 $scope.tasks = _.sortBy(tasks, 'ref')
                 return tasks
 
+        _isVisible = ->
+            if $scope.project
+                return $scope.project.my_permissions.indexOf("view_tasks") != -1
+            return false
+
+        _isEditable = ->
+            if $scope.project
+                return $scope.project.my_permissions.indexOf("modify_task") != -1
+            return false
+
+        $scope.showRelatedTasks = ->
+            return _isVisible() && ( _isEditable() ||  $scope.tasks?.length )
+
         $scope.$on "related-tasks:add", ->
             loadTasks().then ->
                 $rootscope.$broadcast("related-tasks:update")

--- a/app/modules/components/attachments-full/attachments-full.controller.coffee
+++ b/app/modules/components/attachments-full/attachments-full.controller.coffee
@@ -25,10 +25,11 @@ class AttachmentsFullController
         "$tgConfirm",
         "$tgConfig",
         "$tgStorage",
-        "tgAttachmentsFullService"
+        "tgAttachmentsFullService",
+        "tgProjectService"
     ]
 
-    constructor: (@translate, @confirm, @config, @storage, @attachmentsFullService) ->
+    constructor: (@translate, @confirm, @config, @storage, @attachmentsFullService, @projectService) ->
         @.mode = @storage.get('attachment-mode', 'list')
 
         @.maxFileSize = @config.get("maxUploadFileSize", null)
@@ -84,5 +85,13 @@ class AttachmentsFullController
 
     updateAttachment: (toUpdateAttachment) ->
         @attachmentsFullService.updateAttachment(toUpdateAttachment, @.type)
+
+    _isEditable: ->
+        if @projectService.project
+            return @projectService.hasPermission(@.editPermission)
+        return false
+
+    showAttachments: ->
+        return @._isEditable() || @attachmentsFullService.attachments.size
 
 angular.module("taigaComponents").controller("AttachmentsFull", AttachmentsFullController)

--- a/app/modules/components/attachments-full/attachments-full.controller.spec.coffee
+++ b/app/modules/components/attachments-full/attachments-full.controller.spec.coffee
@@ -53,6 +53,14 @@ describe "AttachmentsController", ->
 
         $provide.value("tgAttachmentsFullService", mocks.attachmentsFullService)
 
+    _mockProjectService = ->
+        mocks.projectService = {
+            project: sinon.stub()
+            hasPermission: sinon.stub()
+        }
+
+        $provide.value("tgProjectService", mocks.projectService)
+
     _mocks = ->
         module (_$provide_) ->
             $provide = _$provide_
@@ -62,6 +70,7 @@ describe "AttachmentsController", ->
             _mockConfig()
             _mockStorage()
             _mockAttachmetsFullService()
+            _mockProjectService()
 
             return null
 
@@ -213,3 +222,17 @@ describe "AttachmentsController", ->
         ctrl.updateAttachment(file, 5)
 
         expect(mocks.attachmentsFullService.updateAttachment).to.have.been.calledWith(file, 'us')
+
+    it "if attachments editable", () ->
+        mocks.projectService.project = true
+        ctrl = $controller("AttachmentsFull")
+
+        ctrl._isEditable()
+
+        expect(mocks.projectService.hasPermission).has.been.called
+
+    it "if attachments are not editable", () ->
+        mocks.projectService.project = false
+        ctrl = $controller("AttachmentsFull")
+
+        expect(ctrl._isEditable()).to.be.false

--- a/app/modules/components/attachments-full/attachments-full.directive.coffee
+++ b/app/modules/components/attachments-full/attachments-full.directive.coffee
@@ -28,8 +28,9 @@ AttachmentsFullDirective = () ->
         scope: {},
         bindToController: {
             type: "@",
-            objId: "="
-            projectId: "="
+            objId: "=",
+            projectId: "=",
+            editPermission: "@"
         },
         controller: "AttachmentsFull",
         controllerAs: "vm",

--- a/app/modules/components/attachments-full/attachments-full.jade
+++ b/app/modules/components/attachments-full/attachments-full.jade
@@ -1,4 +1,7 @@
-section.attachments(tg-attachments-drop="vm.addAttachments(files, false)")
+section.attachments(
+    tg-attachments-drop="vm.addAttachments(files, false)"
+    ng-show="vm.showAttachments()"
+)
     .attachments-header
         h3.attachments-title #[span.attachments-num {{vm.attachments.size}}] #[span.attachments-text(translate="ATTACHMENT.SECTION_NAME")]
         .options

--- a/app/partials/includes/modules/related-tasks.jade
+++ b/app/partials/includes/modules/related-tasks.jade
@@ -1,4 +1,7 @@
-section.related-tasks(tg-related-tasks)
+section.related-tasks(
+    tg-related-tasks
+    ng-show="showRelatedTasks()"
+)
     .related-tasks-header
         span.related-tasks-title(translate="COMMON.RELATED_TASKS")
         div(tg-related-task-create-button)

--- a/app/partials/issue/issues-detail.jade
+++ b/app/partials/issue/issues-detail.jade
@@ -77,6 +77,7 @@ div.wrapper(
             obj-id="issue.id"
             type="issue",
             project-id="projectId"
+            edit-permission = "modify_issue"
         )
 
         tg-history(ng-model="issue", type="issue")

--- a/app/partials/task/task-detail.jade
+++ b/app/partials/task/task-detail.jade
@@ -92,8 +92,9 @@ div.wrapper(
 
         tg-attachments-full(
             obj-id="task.id"
-            type="task",
+            type="task"
             project-id="projectId"
+            edit-permission = "modify_task"
         )
 
         tg-history(ng-model="task", type="task")

--- a/app/partials/us/us-detail.jade
+++ b/app/partials/us/us-detail.jade
@@ -89,6 +89,7 @@ div.wrapper(
             obj-id="us.id"
             type="us",
             project-id="projectId"
+            edit-permission = "modify_us"
         )
 
         tg-history(

--- a/app/partials/wiki/wiki.jade
+++ b/app/partials/wiki/wiki.jade
@@ -21,6 +21,7 @@ div.wrapper(ng-controller="WikiDetailController as ctrl",
             obj-id="wiki.id"
             type="wiki_page",
             project-id="projectId"
+            edit-permission = "modify_wiki_page"
         )
 
         a.remove(href="", ng-click="ctrl.delete()", ng-if="wiki.id", title="{{'WIKI.REMOVE' | translate}}", tg-check-permission="delete_wiki_page")


### PR DESCRIPTION
When users have no permissions and are empty, users should not be able to see the related tasks module or the attachments module. Instead, it should be visible even if empty if users can edit.

For related tasks it should be only tested on user story details.
For attachments it should be tested for every attachments full module 