### PR TITLE
Remove a unnecessary double quotation mark

### DIFF
--- a/app/modules/projects/project/project.jade
+++ b/app/modules/projects/project/project.jade
@@ -63,7 +63,7 @@ div.wrapper
                         title="{{'PROJECT.LOOKING_FOR_PEOPLE' | translate}}"
                     )
                     h3 {{'PROJECT.LOOKING_FOR_PEOPLE' | translate}}
-                    p(ng-if="vm.project.get('looking_for_people_note')") {{::vm.project.get('looking_for_people_note')}}"
+                    p(ng-if="vm.project.get('looking_for_people_note')") {{::vm.project.get('looking_for_people_note')}}
                 h2.title {{"PROJECT.SECTION.TEAM" | translate}}
                 ul.involved-team
                     li(tg-repeat="member in vm.members")


### PR DESCRIPTION
Hi, :evergreen_tree: :evergreen_tree: :evergreen_tree: 

I've just found a tiny bug for a unnecessary double quotation mark at the end of [project.jade L66](https://github.com/taigaio/taiga-front/blob/master/app/modules/projects/project/project.jade#L66) ;)

This was found, when I tried `looking for people` on my project in hosted [tree.taiga.io](https://tree.taiga.io/).

![double-quote-after-looking-for-people-note](https://cloud.githubusercontent.com/assets/163063/13378522/8e61f62a-de4c-11e5-8f7d-17d2fdb507c6.png)