### PR TITLE
The eye in the archive column in kanban doesn't change on click

### DIFF
--- a/app/coffee/modules/kanban/main.coffee
+++ b/app/coffee/modules/kanban/main.coffee
@@ -329,7 +329,7 @@ KanbanArchivedStatusHeaderDirective = ($rootscope, $translate) ->
         status = $scope.$eval($attrs.tgKanbanArchivedStatusHeader)
         hidden = true
 
-        $scope.class = "icon-open-eye"
+        $scope.class = "icon-watch"
         $scope.title = showArchivedText
 
         $el.on "click", (event) ->
@@ -337,12 +337,12 @@ KanbanArchivedStatusHeaderDirective = ($rootscope, $translate) ->
 
             $scope.$apply ->
                 if hidden
-                    $scope.class = "icon-open-eye"
+                    $scope.class = "icon-watch"
                     $scope.title = showArchivedText
                     $rootscope.$broadcast("kanban:hide-userstories-for-status", status.id)
 
                 else
-                    $scope.class = "icon-closed-eye"
+                    $scope.class = "icon-unwatch"
                     $scope.title = hideArchivedText
                     $rootscope.$broadcast("kanban:show-userstories-for-status", status.id)
 

--- a/app/partials/includes/modules/kanban-table.jade
+++ b/app/partials/includes/modules/kanban-table.jade
@@ -60,7 +60,7 @@ div.kanban-table(tg-kanban-squish-column)
                         ng-class="class"
                         ng-if="s.is_archived"
                         tg-kanban-archived-status-header="s")
-                        tg-svg.bulk-action(svg-icon="icon-watch")
+                        tg-svg.bulk-action(svg-icon="{{class}}")
 
     div.kanban-table-body
         div.kanban-table-inner


### PR DESCRIPTION
https://tree.taiga.io/project/taiga/issue/4082

Expected in arcchive column:
 - Open eye icon when not visible.
- Closed eye icon when visible