### PR TITLE
Remove assigned text button

### DIFF
--- a/app/partials/common/components/assigned-to.jade
+++ b/app/partials/common/components/assigned-to.jade
@@ -13,6 +13,7 @@
     <% }; %>
 
     .assigned-to-options
+        <% if (isEditable) { %>
         a(
             href=""
             title="{{ 'COMMON.ASSIGNED_TO.TITLE_ACTION_EDIT_ASSIGNMENT'|translate }}"
@@ -25,7 +26,8 @@
                 <% if (isEditable && !isUnassigned) { %>
                 tg-svg(svg-icon="icon-arrow-down")
                 <% }; %>
-
+        <% }; %>
+        
         <% if (isEditable && isUnassigned) { %>
         span(translate="COMMON.OR")
         | &nbsp;


### PR DESCRIPTION
Current: A user who has no permissions to edit can click on a Assign button on Stories that doies not react.

Expected: That button should be hidden.

Fixes: https://tree.taiga.io/project/taiga/issue/4102