### PR TITLE
Refactor icon in lightbox to fix IE bug

### DIFF
--- a/app/coffee/modules/common/confirm.coffee
+++ b/app/coffee/modules/common/confirm.coffee
@@ -173,14 +173,17 @@ class ConfirmService extends taiga.Service
             if icon.type == "img"
                 detailImage = $('<img>').addClass('lb-icon').attr('src', icon.name)
             else if icon.type == "svg"
+                detailImage = document.createElement("div")
+                taiga.addClass(detailImage, "icon")
+                taiga.addClass(detailImage, icon.name)
+                taiga.addClass(detailImage, "lb-icon")
+
+                svgContainer = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+
                 useSVG = document.createElementNS('http://www.w3.org/2000/svg', 'use')
                 useSVG.setAttributeNS('http://www.w3.org/1999/xlink','href', '#' + icon.name)
 
-                detailImage = document.createElementNS("http://www.w3.org/2000/svg", "svg")
-                taiga.addClass(detailImage, "icon")
-                taiga.addClass(detailImage, "lb-icon")
-                taiga.addClass(detailImage, icon.name)
-                detailImage.appendChild(useSVG)
+                detailImage.appendChild(svgContainer).appendChild(useSVG)
 
             if detailImage
                 el.find('section').prepend(detailImage)

--- a/app/styles/dependencies/helpers.scss
+++ b/app/styles/dependencies/helpers.scss
@@ -55,10 +55,14 @@
         transition: opacity .3s ease;
     }
     .lb-icon {
-        @include svg-size(6rem);
-        display: block;
-        fill: $whitish;
         margin: 1rem auto;
+        display: flex;
+        justify-content: center;
+        svg {
+            @include svg-size(6rem);
+            display: block;
+            fill: $whitish;
+        }
     }
     .title {
         text-align: center;


### PR DESCRIPTION
Fixes: https://tree.taiga.io/project/taiga/issue/4083

How to test: 
- Browser: IE11
- Transfer a project to a user, confirmation light box should have an icon on top (a :heart: ) and should be visible  (6 rem tall) and centered, light gray color.