### PR TITLE
Point by tag counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog #
 
 
+## 2.2.0 ???? (Unreleased)
+
+### Features
+- Show a confirmation notice when you exit edit mode by pressing ESC in the markdown inputs.
+
+### Misc
+- Lots of small and not so small bugfixes.
+
+
 ## 2.1.0 Ursus Americanus (2016-05-03)
 
 ### Features

--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -63,7 +63,8 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         bindMethods(@)
 
         @.page = 1
-        @.disablePagination = true
+        @.disablePagination = false
+        @.firstLoadComplete = false
         @scope.userstories = []
 
         @scope.sectionName = @translate.instant("BACKLOG.SECTION_NAME")
@@ -77,7 +78,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
         # On Success
         promise.then =>
-            @.disablePagination = false
+            @.firstLoadComplete = true
 
             title = @translate.instant("BACKLOG.PAGE_TITLE", {projectName: @scope.project.name})
             description = @translate.instant("BACKLOG.PAGE_DESCRIPTION", {
@@ -267,7 +268,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
     loadUserstories: (resetPagination = false, pageSize) ->
         return null if !@scope.projectId
-        
+
         @.loadingUserstories = true
         @.disablePagination = true
         @scope.httpParams = @.getUrlFilters()

--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -63,7 +63,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         bindMethods(@)
 
         @.page = 1
-        @.disablePagination = false
+        @.disablePagination = true
         @scope.userstories = []
 
         @scope.sectionName = @translate.instant("BACKLOG.SECTION_NAME")
@@ -77,6 +77,8 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
         # On Success
         promise.then =>
+            @.disablePagination = false
+
             title = @translate.instant("BACKLOG.PAGE_TITLE", {projectName: @scope.project.name})
             description = @translate.instant("BACKLOG.PAGE_DESCRIPTION", {
                 projectName: @scope.project.name,
@@ -264,6 +266,8 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
           @.page = page
 
     loadUserstories: (resetPagination = false, pageSize) ->
+        return null if !@scope.projectId
+        
         @.loadingUserstories = true
         @.disablePagination = true
         @scope.httpParams = @.getUrlFilters()

--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -142,7 +142,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
     initializeSubscription: ->
         routingKey1 = "changes.project.#{@scope.projectId}.userstories"
         @events.subscribe @scope, routingKey1, (message) =>
-            @.loadUserstories()
+            @.loadAllPaginatedUserstories()
             @.loadSprints()
 
         routingKey2 = "changes.project.#{@scope.projectId}.milestones"
@@ -257,7 +257,13 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
         @.loadUserstories()
 
-    loadUserstories: (resetPagination = false)->
+    loadAllPaginatedUserstories: () ->
+        page = @.page
+
+        @.loadUserstories(true, @scope.userstories.length).then () =>
+          @.page = page
+
+    loadUserstories: (resetPagination = false, pageSize) ->
         @.loadingUserstories = true
         @.disablePagination = true
         @scope.httpParams = @.getUrlFilters()
@@ -268,7 +274,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
         @scope.httpParams.page = @.page
 
-        promise = @rs.userstories.listUnassigned(@scope.projectId, @scope.httpParams)
+        promise = @rs.userstories.listUnassigned(@scope.projectId, @scope.httpParams, pageSize)
 
         return promise.then (result) =>
             userstories = result[0]

--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -304,9 +304,8 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
             # We can't assure when this exactly happens so we need a defer
             scopeDefer @scope, =>
                 @scope.$broadcast("userstories:loaded")
-            @.tag_point=0
-            #317
             if @.getUrlFilters().tags != undefined
+              @.tag_point=0
               for userstory in userstories
                 @.tag_point += userstory.total_points
               console.log(@.tag_point)

--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -66,6 +66,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         @.disablePagination = false
         @.firstLoadComplete = false
         @scope.userstories = []
+        @.tag_point = null;
 
         @scope.sectionName = @translate.instant("BACKLOG.SECTION_NAME")
         @showTags = false
@@ -164,7 +165,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         return @rs.projects.stats(@scope.projectId).then (stats) =>
             @scope.stats = stats
             totalPoints = if stats.total_points then stats.total_points else stats.defined_points
-
+            stats.tag_points=@.tag_point
             if totalPoints
                 @scope.stats.completedPercentage = Math.round(100 * stats.closed_points / totalPoints)
             else
@@ -303,7 +304,15 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
             # We can't assure when this exactly happens so we need a defer
             scopeDefer @scope, =>
                 @scope.$broadcast("userstories:loaded")
-
+            @.tag_point=0
+            #317
+            if @.getUrlFilters().tags != undefined
+              for userstory in userstories
+                @.tag_point += userstory.total_points
+              console.log(@.tag_point)
+            else
+              @.tag_point = null
+            @.loadProjectStats()
             return userstories
 
     loadBacklog: ->

--- a/app/coffee/modules/backlog/sortable.coffee
+++ b/app/coffee/modules/backlog/sortable.coffee
@@ -93,7 +93,10 @@ BacklogSortableDirective = ($repo, $rs, $rootscope, $tgConfirm, $translate) ->
                 parent = $(item).parent()
                 isBacklog = parent.hasClass('backlog-table-body') || parent.hasClass('empty-backlog')
 
-                sameContainer = (initIsBacklog == isBacklog)
+                if initIsBacklog || isBacklog
+                    sameContainer = (initIsBacklog == isBacklog)
+                else
+                    sameContainer = $(item).scope().sprint.id == parent.scope().sprint.id
 
                 dragMultipleItems = window.dragMultiple.stop()
 

--- a/app/coffee/modules/common/confirm.coffee
+++ b/app/coffee/modules/common/confirm.coffee
@@ -59,9 +59,9 @@ class ConfirmService extends taiga.Service
         el = angular.element(lightboxSelector)
 
         # Render content
-        el.find(".title").text(title)
-        el.find(".subtitle").text(subtitle)
-        el.find(".message").text(message)
+        el.find(".title").text(title) if title
+        el.find(".subtitle").text(subtitle) if subtitle
+        el.find(".message").text(message) if message
 
         # Assign event handlers
         el.on "click.confirm-dialog", ".button-green", debounce 2000, (event) =>

--- a/app/coffee/modules/resources/userstories.coffee
+++ b/app/coffee/modules/resources/userstories.coffee
@@ -47,11 +47,14 @@ resourceProvider = ($repo, $http, $urls, $storage) ->
     service.filtersData = (params) ->
         return $repo.queryOneRaw("userstories-filters", null, params)
 
-    service.listUnassigned = (projectId, filters) ->
+    service.listUnassigned = (projectId, filters, pageSize) ->
         params = {"project": projectId, "milestone": "null"}
         params = _.extend({}, params, filters or {})
         service.storeQueryParams(projectId, params)
-        return $repo.queryMany("userstories", params, {
+
+        return $repo.queryMany("userstories", _.extend(params, {
+            page_size: pageSize
+        }), {
             enablePagination: true
         }, true)
 

--- a/app/coffee/modules/wiki/main.coffee
+++ b/app/coffee/modules/wiki/main.coffee
@@ -206,7 +206,7 @@ module.directive("tgWikiSummary", ["$log", "$tgTemplate", "$compile", "$translat
 ## Editable Wiki Content Directive
 #############################################################################
 
-EditableWikiContentDirective = ($window, $document, $repo, $confirm, $loading, $analytics, $qqueue) ->
+EditableWikiContentDirective = ($window, $document, $repo, $confirm, $loading, $analytics, $qqueue, $translate) ->
     link = ($scope, $el, $attrs, $model) ->
         isEditable = ->
             return $scope.project.my_permissions.indexOf("modify_wiki_page") != -1
@@ -227,8 +227,8 @@ EditableWikiContentDirective = ($window, $document, $repo, $confirm, $loading, $
         cancelEdition = ->
             return if not $model.$modelValue.id
 
-            $scope.$apply () =>
-                $model.$modelValue.revert()
+            $model.$modelValue.revert()
+
             switchToReadMode()
 
         getSelectedText = ->
@@ -290,11 +290,15 @@ EditableWikiContentDirective = ($window, $document, $repo, $confirm, $loading, $
             save($scope.wiki)
 
         $el.on "click", ".cancel", ->
-            cancelEdition()
+            $scope.$apply(cancelEdition)
 
         $el.on "keydown", "textarea", (event) ->
             if event.keyCode == 27
-                cancelEdition()
+                $scope.$applyAsync () ->
+                    confirmTitle = $translate.instant("COMMON.CONFIRM_CLOSE_EDIT_MODE")
+                    $confirm.ask(confirmTitle).then (askResponse) ->
+                        cancelEdition()
+                        askResponse.finish()
 
         $scope.$watch $attrs.ngModel, (wikiPage) ->
             return if not wikiPage
@@ -317,4 +321,4 @@ EditableWikiContentDirective = ($window, $document, $repo, $confirm, $loading, $
     }
 
 module.directive("tgEditableWikiContent", ["$window", "$document", "$tgRepo", "$tgConfirm", "$tgLoading",
-                                           "$tgAnalytics", "$tgQqueue", EditableWikiContentDirective])
+                                           "$tgAnalytics", "$tgQqueue", "$translate", EditableWikiContentDirective])

--- a/app/locales/taiga/locale-ca.json
+++ b/app/locales/taiga/locale-ca.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "El teu text ací...",
             "PREVIEW_BUTTON": "Previsualitzar",
             "EDIT_BUTTON": "Editar",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Ajuda de Markdown"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/locales/taiga/locale-ca.json
+++ b/app/locales/taiga/locale-ca.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Aquest valor pareix invàlid.",
             "TYPE_EMAIL": "Deu ser un correu vàlid.",

--- a/app/locales/taiga/locale-de.json
+++ b/app/locales/taiga/locale-de.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
         "OWNER": "Projekteigentümer",
         "CAPSLOCK_WARNING": "Achtung! Sie verwenden Großbuchstaben in einem Eingabefeld, dass Groß- und Kleinschreibung berücksichtigt.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Dieser Wert scheint ungültig zu sein.",
             "TYPE_EMAIL": "Dieser Wert sollte eine gültige E-Mail Adresse enthalten.",

--- a/app/locales/taiga/locale-de.json
+++ b/app/locales/taiga/locale-de.json
@@ -50,7 +50,7 @@
             "TYPE_URLSTRICT": "Dieser Wert sollte eine gültige URL enthalten.",
             "TYPE_NUMBER": "Dieser Wert sollte eine gültige Nummer enthalten.",
             "TYPE_DIGITS": "Dieser Wert sollte Ziffern enthalten.",
-            "TYPE_DATEISO": "Dieser Wert sollte ein gültiges Datum sein (JJJJ-MM-TT)",
+            "TYPE_DATEISO": "Dieser Wert sollte ein gültiges Datum sein (YYYY-MM-DD)",
             "TYPE_ALPHANUM": "Dieser Wert sollte alphanumersich sein.",
             "TYPE_PHONE": "Dieser Wert sollte eine gültige Telefonnummer enthalten.",
             "NOTNULL": "Dieser Wert darf nicht leer sein.",
@@ -67,8 +67,8 @@
             "MAX_CHECK": "Wählen Sie %s oder weniger.",
             "RANGE_CHECK": "Wählen Sie zwischen  %s und %s",
             "EQUAL_TO": "Dieser Wert sollte der gleiche sein.",
-            "LINEWIDTH": "One or more lines is perhaps too long. Try to keep under %s characters.",
-            "PIKADAY": "Ungültiges Datumsformat. Bitte nutze DD MMM JJJJ (etwa 23 März 1984)"
+            "LINEWIDTH": "Eine oder mehrere Zeilen sind vielleicht zu lang. Versuchen Sie unter %s Zeichen zu bleiben.",
+            "PIKADAY": "Ungültiges Datumsformat. Bitte nutze DD MMM YYYY (etwa 23 März 1984)"
         },
         "PICKERDATE": {
             "FORMAT": "DD MMM YYYY",
@@ -225,7 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Text...",
             "PREVIEW_BUTTON": "Vorschau",
             "EDIT_BUTTON": "Bearbeiten",
-            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
+            "ATTACH_FILE_HELP": "Dateien per Drag & Drop auf das obere Textfeld anhängen.",
             "MARKDOWN_HELP": "Markdown syntax Hilfe"
         },
         "PERMISIONS_CATEGORIES": {
@@ -474,12 +474,12 @@
             "ACTION_USE_DEFAULT_LOGO": "Nutze Standardbild",
             "MAX_PRIVATE_PROJECTS": "Sie haben die maximale Anzahl privater Projekte erreicht, die in Ihrem derzeitigen Plan erlaubt sind",
             "MAX_PRIVATE_PROJECTS_MEMBERS": "Die maximale Anzahl von Mitgliedern für privater Projekte sind erreicht",
-            "MAX_PUBLIC_PROJECTS": "Unfortunately, you've reached the maximum number of public projects allowed by your current plan",
-            "MAX_PUBLIC_PROJECTS_MEMBERS": "The project exceeds your maximum number of members for public projects",
+            "MAX_PUBLIC_PROJECTS": "Leider haben Sie die maximale Anzahl öffentlicher Projekte erreicht, die in Ihrem derzeitigen Plan erlaubt sind",
+            "MAX_PUBLIC_PROJECTS_MEMBERS": "Die maximale Anzahl von Mitgliedern für öffentliche Projekte sind erreicht",
             "PROJECT_OWNER": "Projekteigentümer",
             "REQUEST_OWNERSHIP": "Besitz beantragen",
             "REQUEST_OWNERSHIP_CONFIRMATION_TITLE": "Möchtest du der neue Projektleiter werden?",
-            "REQUEST_OWNERSHIP_DESC": "Request that current project owner {{name}} transfer ownership of this project to you.",
+            "REQUEST_OWNERSHIP_DESC": "Anfrage vom derzeitigen Projektleiter {{name}}, die Leitung für dieses Projekt zu übernehmen.",
             "REQUEST_OWNERSHIP_BUTTON": "Anfrage",
             "REQUEST_OWNERSHIP_SUCCESS": "Wir werden den Projektleiter benachrichtigen",
             "CHANGE_OWNER": "Ändere Besitzer",
@@ -699,15 +699,15 @@
             "REJECTED_PROJECT_OWNERNSHIP": "Ok, wir kontaktieren den aktuellen Projektleiter",
             "ACCEPT": "Akzeptieren",
             "REJECT": "Zurückweisen",
-            "PROPOSE_OWNERSHIP": "<strong>{{owner}}</strong>, the current owner of the project <strong>{{project}}</strong> has asked that you become the new  project owner.",
+            "PROPOSE_OWNERSHIP": "<strong>{{owner}}</strong>, der derzeitige Leiter des Projekts <strong>{{project}}</strong> hat Sie gefragt, ob Sie der neue Projektleiter werden möchten.",
             "ADD_COMMENT": "Möchten Sie einen Kommentar für den Projektleiter hinzufügen?",
             "UNLIMITED_PROJECTS": "Unbegrenzt",
             "OWNER_MESSAGE": {
-                "PRIVATE": "Please remember that you can own up to <strong>{{maxProjects}}</strong> private projects. You currently own <strong>{{currentProjects}}</strong> private projects",
-                "PUBLIC": "Please remember that you can own up to <strong>{{maxProjects}}</strong> public projects. You currently own <strong>{{currentProjects}}</strong> public projects"
+                "PRIVATE": "Bitte denken Sie daran, dass Sie bis zu <strong>{{maxProjects}}</strong> private Projekte besitzen können. Dezeit besitzen Sie <strong>{{currentProjects}}</strong> private Projekte",
+                "PUBLIC": "Bitte denken Sie daran, dass Sie bis zu <strong>{{maxProjects}}</strong> öffentliche Projekte besitzen können. Dezeit besitzen Sie <strong>{{currentProjects}}</strong> öffentliche Projekte"
             },
-            "CANT_BE_OWNED": "At the moment you cannot become an owner of a project of this type. If you would like to become the owner of this project, please contact the administrator so they change your account settings to enable project ownership.",
-            "CHANGE_MY_PLAN": "Change my plan"
+            "CANT_BE_OWNED": "Zur Zeit können Sie kein Projektleiter für diesen Projekt-Typ werden werden. Wenn Sie Projektleiter für dieses Projekt werden möchten, kontaktieren Sie bitte den Administrator, damit er Ihre Benutzerkonto-Einstellungen anpassen kann, um Projektleiter werden zu können.",
+            "CHANGE_MY_PLAN": "Meinen Plan ändern"
         }
     },
     "USER": {
@@ -836,28 +836,28 @@
             "ERROR_MAX_SIZE_EXCEEDED": "'{{fileName}}' ({{fileSize}}) ist zu schwierig für unsere Helferlein, versuchen Sie es bitte mit einer kleineren Datei als ({{maxFileSize}})",
             "SYNC_SUCCESS": "Ihr Projekt wurde erfolgreich importiert",
             "PROJECT_RESTRICTIONS": {
-                "PROJECT_MEMBERS_DESC": "The project you are trying to import has {{members}} members, unfortunately, your current plan allows for a maximum of {{max_memberships}} members per project. If you would like to increase that limit please contact the administrator.",
+                "PROJECT_MEMBERS_DESC": "Das Projekt, dass Sie importieren möchten, hat {{members}} Mitglieder. Leider erlaubt ihr derzeitiger Plan nicht mehr als {{max_memberships}} Mitglieder pro Projekt. Wenn Sie diese Grenze erhöhen möchten, kontaktieren Sie bitte den Administrator.",
                 "PRIVATE_PROJECTS_SPACE": {
-                    "TITLE": "Unfortunately, your current plan does not allow for additional private projects",
-                    "DESC": "The project you are trying to import is private. Unfortunately, your current plan does not allow for additional private projects."
+                    "TITLE": "Leider erlaubt Ihr derzeitiger Plan keine weiteren privaten Projekte anzulegen.",
+                    "DESC": "Das Projekt, das Sie versuchen zu importieren, ist privat. Leider erlaubt Ihr derzeitiger Plan keine weiteren privaten Projekte hinzuzufügen."
                 },
                 "PUBLIC_PROJECTS_SPACE": {
-                    "TITLE": "Unfortunately, your current plan does not allow for additional public projects",
-                    "DESC": "The project you are trying to import is public. Unfortunately, your current plan does not allow additional public projects."
+                    "TITLE": "Leider erlaubt Ihr derzeitiger Plan keine weiteren öffentlichen Projekte anzulegen.",
+                    "DESC": "Das Projekt, das Sie versuchen zu importieren, ist öffentlich. Leider erlaubt Ihr derzeitiger Plan keine weiteren öffentlichen Projekte hinzuzufügen."
                 },
                 "PRIVATE_PROJECTS_MEMBERS": {
-                    "TITLE": "Your current plan allows for a maximum of {{max_memberships}} members per private project"
+                    "TITLE": "Ihr derzeitiger Plan erlaubt maximal {{max_memberships}} Mitglieder pro privatem Projekt"
                 },
                 "PUBLIC_PROJECTS_MEMBERS": {
-                    "TITLE": "Your current plan allows for a maximum of {{max_memberships}} members per public project."
+                    "TITLE": "Ihr derzeitiger Plan erlaubt maximal {{max_memberships}} Mitglieder pro öffentlichem Projekt"
                 },
                 "PRIVATE_PROJECTS_SPACE_MEMBERS": {
-                    "TITLE": "Unfortunately your current plan doesn't allow additional private projects or an increase of more than {{max_memberships}} members per private project",
-                    "DESC": "The project that you are trying to import is private and has {{members}} members."
+                    "TITLE": "Leider erlaubt Ihr derzeitiger Plan keine weiteren privaten Projekte anzulegen oder eine Erhöhung von mehr als {{max_memberships}} Mitglieder pro privatem Projekt",
+                    "DESC": "Das Projekt, dass Sie importieren möchten, ist privat und hat {{members}} Mitglieder."
                 },
                 "PUBLIC_PROJECTS_SPACE_MEMBERS": {
-                    "TITLE": "Unfortunately your current plan doesn't allow additional public projects or an increase of more than {{max_memberships}} members per public project",
-                    "DESC": "The project that you are trying to import is public and has more than {{members}} members."
+                    "TITLE": "Leider erlaubt Ihr derzeitiger Plan keine weiteren öffentlichen Projekte anzulegen oder eine Erhöhung von mehr als {{max_memberships}} Mitglieder pro öffentlichem Projekt",
+                    "DESC": "Das Projekt, dass Sie importieren möchten, ist öffentlich und hat mehr als {{members}} Mitglieder."
                 }
             }
         },
@@ -1126,7 +1126,7 @@
         },
         "SPRINTS": {
             "TITLE": "SPRINTS",
-            "DATE": "TT MMM JJJJ",
+            "DATE": "DD MMM YYYY",
             "LINK_TASKBOARD": "Sprint Taskboard",
             "TITLE_LINK_TASKBOARD": "Gehe zu Taskboard von \"{{name}}\"",
             "NUMBER_SPRINTS": "<br/>Sprints",
@@ -1403,13 +1403,13 @@
         "PRIVATE_PROJECT": "Privates Projekt",
         "CREATE_PROJECT": "Projekt anlegen",
         "MAX_PRIVATE_PROJECTS": "Sie haben die maximale Anzahl privater Projekte erreicht",
-        "MAX_PUBLIC_PROJECTS": "Unfortunately, you've reached the maximum number of public projects",
+        "MAX_PUBLIC_PROJECTS": "Leider haben Sie die maximale Anzahl öffentlicher Projekte erreicht",
         "CHANGE_PLANS": "Änderungs-Pläne"
     },
     "WIKI": {
         "PAGE_TITLE": "{{wikiPageName}} - Wiki - {{projectName}}",
         "PAGE_DESCRIPTION": "Letzte Bearbeitung am {{lastModifiedDate}} ({{totalEditions}} Gesamtzahl der Bearbeitungen) Inhalt: {{ wikiPageContent }}",
-        "DATETIME": "TT MMM JJJJ hh:mm",
+        "DATETIME": "DD MMM YYYY HH:mm",
         "PLACEHOLDER_PAGE": "Schreiben Sie Ihre Wiki Seite",
         "REMOVE": "Diese Wiki Seite entfernen",
         "DELETE_LIGHTBOX_TITLE": "Wiki Seite löschen",

--- a/app/locales/taiga/locale-de.json
+++ b/app/locales/taiga/locale-de.json
@@ -2,7 +2,7 @@
     "COMMON": {
         "YES": "Ja",
         "NO": "Nein",
-        "OR": "or",
+        "OR": "oder",
         "LOADING": "Wird geladen...",
         "LOADING_PROJECT": "Projekt wird geladen...",
         "DATE": "DD MMM YYYY",
@@ -41,8 +41,8 @@
         "IOCAINE_TEXT": "Fühlen Sie sich von einer Aufgabe etwas erdrückt? Stellen Sie sicher, dass andere davon erfahren, indem Sie auf Locaine klicken, wenn Sie eine Aufgabe ändern. Es ist möglich, gegen dieses (fiktive) tödliche Gift immun zu werden, indem man kleine Mengen über einen Zeitraum hinweg einnimmt. Genauso, wie es möglich ist, besser in dem zu werden, was man tut, indem man gelegentlich zusätzliche Herausforderungen annimmt!",
         "CLIENT_REQUIREMENT": "Client requirement is new requirement that was not previously expected and it is required to be part of the project",
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
-        "OWNER": "Project Owner",
-        "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "OWNER": "Projekteigentümer",
+        "CAPSLOCK_WARNING": "Achtung! Sie verwenden Großbuchstaben in einem Eingabefeld, dass Groß- und Kleinschreibung berücksichtigt.",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Dieser Wert scheint ungültig zu sein.",
             "TYPE_EMAIL": "Dieser Wert sollte eine gültige E-Mail Adresse enthalten.",
@@ -68,7 +68,7 @@
             "RANGE_CHECK": "Wählen Sie zwischen  %s und %s",
             "EQUAL_TO": "Dieser Wert sollte der gleiche sein.",
             "LINEWIDTH": "One or more lines is perhaps too long. Try to keep under %s characters.",
-            "PIKADAY": "Invalid date format, please use DD MMM YYYY (like 23 Mar 1984)"
+            "PIKADAY": "Ungültiges Datumsformat. Bitte nutze DD MMM JJJJ (etwa 23 März 1984)"
         },
         "PICKERDATE": {
             "FORMAT": "DD MMM YYYY",
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Text...",
             "PREVIEW_BUTTON": "Vorschau",
             "EDIT_BUTTON": "Bearbeiten",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Markdown syntax Hilfe"
         },
         "PERMISIONS_CATEGORIES": {
@@ -319,8 +320,8 @@
         "PLACEHOLDER_FIELD": "Benutzername oder E-Mail-Adresse",
         "ACTION_RESET_PASSWORD": "Passwort zurücksetzen",
         "LINK_CANCEL": "Nein, bring mich zurück. Ich denke, ich erinnere mich daran.",
-        "SUCCESS_TITLE": "Check your inbox!",
-        "SUCCESS_TEXT": "We sent you an email with the instructions to set a new password",
+        "SUCCESS_TITLE": "Prüfen Sie bitte Ihre Emails!",
+        "SUCCESS_TEXT": "Wir haben Ihnen eine Email mit den Anweisungen zum ändern Ihres Passworts geschickt",
         "ERROR": "Laut unseren Helferlein sind Sie bislang noch nicht registriert."
     },
     "CHANGE_PASSWORD": {
@@ -356,7 +357,7 @@
     "HOME": {
         "PAGE_TITLE": "Home - Taiga",
         "PAGE_DESCRIPTION": "Die Taiga Homepage mit Ihren wichtigsten Projekten und all Ihren zugeordneten und beobachteten User-Stories, Aufgaben und Tickets.",
-        "EMPTY_WORKING_ON": "<strong>It feels empty, doesn't it?</strong> Start working with Taiga and you'll see here the stories, tasks and issues you are working on.",
+        "EMPTY_WORKING_ON": "<strong>Es sieht hier noch leer aus, oder?</strong> Beginne mit Taiga zu arbeiten und du wirst hier Storys, Tasks und Issues an denen gearbeitet wird sehen.",
         "EMPTY_WATCHING": "<strong>Folge</strong> User Stories, Tasks, Issues in deinem Projekt und erhalte Benachrichtigungen, wenn sich etwas ändert. :)",
         "EMPTY_PROJECT_LIST": "Sie haben noch keine Projekte",
         "WORKING_ON_SECTION": "Zuletzt bearbeitet",
@@ -411,8 +412,8 @@
             "PAGE_TITLE": "Mitgliedschaften - {{projectName}}",
             "ADD_BUTTON": "+ Neues Mitglied",
             "ADD_BUTTON_TITLE": "Neues Mitglied hinzufügen",
-            "LIMIT_USERS_WARNING_MESSAGE_FOR_ADMIN": "Unfortunately, this project has reached its limit of <strong>({{members}})</strong> allowed members.",
-            "LIMIT_USERS_WARNING_MESSAGE_FOR_OWNER": "This project has reached its limit of <strong>({{members}})</strong> allowed members. If you would like to increase that limit please contact the administrator."
+            "LIMIT_USERS_WARNING_MESSAGE_FOR_ADMIN": "Leider hat dieses Projekt sein Limit von <strong>({{members}})</strong> Mitgliedern bereits erreicht",
+            "LIMIT_USERS_WARNING_MESSAGE_FOR_OWNER": "Dieses Projekt hat seine Grenze von <strong>({{members}})</strong> erlaubten Mitgliedern erreicht. Wenn Sie diese Grenze erhöhen möchten, kontaktieren Sie den Administrator."
         },
         "PROJECT_EXPORT": {
             "TITLE": "Exportieren",
@@ -434,10 +435,10 @@
             "DISABLE": "Deaktivieren",
             "BACKLOG": "Auftragsliste",
             "BACKLOG_DESCRIPTION": "Verwalten Sie Ihre User-Stories, um einen organisierten Überblick der anstehenden und priorisierten Aufgaben zu erhalten.",
-            "NUMBER_SPRINTS": "Expected number of sprints",
-            "NUMBER_SPRINTS_HELP": "0 for an undetermined number",
-            "NUMBER_US_POINTS": "Expected total of story points",
-            "NUMBER_US_POINTS_HELP": "0 for an undetermined number",
+            "NUMBER_SPRINTS": "Erwartete Anzahl an Sprints",
+            "NUMBER_SPRINTS_HELP": "0 für eine unbestimmte Anzahl",
+            "NUMBER_US_POINTS": "Erwartete Gesamt-Story-Punkte",
+            "NUMBER_US_POINTS_HELP": "0 für eine unbestimmte Anzahl",
             "KANBAN": "Kanban",
             "KANBAN_DESCRIPTION": "Organisieren Sie Ihr Projekt auf übersichtliche Art.",
             "ISSUES": "Tickets",
@@ -445,9 +446,9 @@
             "WIKI": "Wiki",
             "WIKI_DESCRIPTION": "Fügen Sie Inhalte hinzu, ändern oder löschen Sie sie in Zusammenarbeit mit anderen. Dies ist der richtige Ort für Ihre Projektdokumentation.",
             "MEETUP": "Zusammentreffen",
-            "MEETUP_DESCRIPTION": "Choose your videoconference system.",
+            "MEETUP_DESCRIPTION": "Wähle Sie Ihr Videokonferenzsystem.",
             "SELECT_VIDEOCONFERENCE": "Wählen Sie ein Videokonferenzsystem",
-            "SALT_CHAT_ROOM": "Add a prefix to the chatroom name",
+            "SALT_CHAT_ROOM": "Fügen Sie ein Präfix für den Chatraum-Namen hinzu",
             "JITSI_CHAT_ROOM": "Jitsi",
             "APPEARIN_CHAT_ROOM": "Erscheint in",
             "TALKY_CHAT_ROOM": "Gesprächig",
@@ -471,19 +472,19 @@
             "LOGO_HELP": "Das Bild wird auf 80x80px skaliert.",
             "CHANGE_LOGO": "Logo ändern",
             "ACTION_USE_DEFAULT_LOGO": "Nutze Standardbild",
-            "MAX_PRIVATE_PROJECTS": "You've reached the maximum number of private projects allowed by your current plan",
-            "MAX_PRIVATE_PROJECTS_MEMBERS": "The maximum number of members for private projects has been exceeded",
+            "MAX_PRIVATE_PROJECTS": "Sie haben die maximale Anzahl privater Projekte erreicht, die in Ihrem derzeitigen Plan erlaubt sind",
+            "MAX_PRIVATE_PROJECTS_MEMBERS": "Die maximale Anzahl von Mitgliedern für privater Projekte sind erreicht",
             "MAX_PUBLIC_PROJECTS": "Unfortunately, you've reached the maximum number of public projects allowed by your current plan",
             "MAX_PUBLIC_PROJECTS_MEMBERS": "The project exceeds your maximum number of members for public projects",
-            "PROJECT_OWNER": "Project owner",
-            "REQUEST_OWNERSHIP": "Request ownership",
-            "REQUEST_OWNERSHIP_CONFIRMATION_TITLE": "Do you want to become the new project owner?",
+            "PROJECT_OWNER": "Projekteigentümer",
+            "REQUEST_OWNERSHIP": "Besitz beantragen",
+            "REQUEST_OWNERSHIP_CONFIRMATION_TITLE": "Möchtest du der neue Projektleiter werden?",
             "REQUEST_OWNERSHIP_DESC": "Request that current project owner {{name}} transfer ownership of this project to you.",
             "REQUEST_OWNERSHIP_BUTTON": "Anfrage",
-            "REQUEST_OWNERSHIP_SUCCESS": "We'll notify the project owner",
-            "CHANGE_OWNER": "Change owner",
-            "CHANGE_OWNER_SUCCESS_TITLE": "Ok, your request has been sent!",
-            "CHANGE_OWNER_SUCCESS_DESC": "We will notify you by email if the project ownership request is accepted or declined"
+            "REQUEST_OWNERSHIP_SUCCESS": "Wir werden den Projektleiter benachrichtigen",
+            "CHANGE_OWNER": "Ändere Besitzer",
+            "CHANGE_OWNER_SUCCESS_TITLE": "Ok, deine Anfrage wurde versendet!",
+            "CHANGE_OWNER_SUCCESS_DESC": "Wir informieren Sie via Email, ob sie als neuer Projektleiter akzeptiert wurden oder ob die Anfrage zurückgewiesen wurde."
         },
         "REPORTS": {
             "TITLE": "Berichte",
@@ -562,7 +563,7 @@
             "COUNT_MEMBERS": "{{ role.members_count }} Mitglieder mit dieser Rolle",
             "TITLE_DELETE_ROLE": "Rolle löschen",
             "REPLACEMENT_ROLE": "Alle Benutzer mit dieser Rolle werden verschoben nach",
-            "WARNING_DELETE_ROLE": "Be careful! All role estimations will be removed",
+            "WARNING_DELETE_ROLE": "Achtung! Alle Rollenverteilungen werden entfernt.",
             "ERROR_DELETE_ALL": "Sie können nicht alle Werte löschen",
             "EXTERNAL_USER": "Externer Benutzer"
         },
@@ -692,15 +693,15 @@
             "TITLE": "Dienste"
         },
         "PROJECT_TRANSFER": {
-            "DO_YOU_ACCEPT_PROJECT_OWNERNSHIP": "Would you like to become the new project owner?",
-            "PRIVATE": "Private",
-            "ACCEPTED_PROJECT_OWNERNSHIP": "Congratulations! You're now the new project owner.",
-            "REJECTED_PROJECT_OWNERNSHIP": "OK. We'll contact the current project owner",
+            "DO_YOU_ACCEPT_PROJECT_OWNERNSHIP": "Möchten Sie der neue Projektleiter werden?",
+            "PRIVATE": "Privat",
+            "ACCEPTED_PROJECT_OWNERNSHIP": "Herzlichen Glückwunsch. Sie sind der neue Projektleiter.",
+            "REJECTED_PROJECT_OWNERNSHIP": "Ok, wir kontaktieren den aktuellen Projektleiter",
             "ACCEPT": "Akzeptieren",
-            "REJECT": "Reject",
+            "REJECT": "Zurückweisen",
             "PROPOSE_OWNERSHIP": "<strong>{{owner}}</strong>, the current owner of the project <strong>{{project}}</strong> has asked that you become the new  project owner.",
-            "ADD_COMMENT": "Would you like to add a comment for the project owner?",
-            "UNLIMITED_PROJECTS": "Unlimited",
+            "ADD_COMMENT": "Möchten Sie einen Kommentar für den Projektleiter hinzufügen?",
+            "UNLIMITED_PROJECTS": "Unbegrenzt",
             "OWNER_MESSAGE": {
                 "PRIVATE": "Please remember that you can own up to <strong>{{maxProjects}}</strong> private projects. You currently own <strong>{{currentProjects}}</strong> private projects",
                 "PUBLIC": "Please remember that you can own up to <strong>{{maxProjects}}</strong> public projects. You currently own <strong>{{currentProjects}}</strong> public projects"
@@ -768,9 +769,9 @@
         "WATCHERS_COUNTER_TITLE": "{total, plural, one{ein Beobachter} andere{# Beobachter}}",
         "MEMBERS_COUNTER_TITLE": "{total, plural, one{one member} andere{# members}}",
         "BLOCKED_PROJECT": {
-            "BLOCKED": "Blocked project",
-            "THIS_PROJECT_IS_BLOCKED": "This project is temporarily blocked",
-            "TO_UNBLOCK_CONTACT_THE_ADMIN_STAFF": "In order to unblock your projects, contact the administrator."
+            "BLOCKED": "Blockiertes Projekt",
+            "THIS_PROJECT_IS_BLOCKED": "Dieses Projekt ist vorrübergehend blockiert",
+            "TO_UNBLOCK_CONTACT_THE_ADMIN_STAFF": "Um dein Projekt zu entsperren kontaktiere bitte einen Administrator."
         },
         "STATS": {
             "PROJECT": "Projekt<br/> Punkte",
@@ -887,10 +888,10 @@
             "SECTION_NAME": "Dein Taiga Benutzerkonto löschen",
             "CONFIRM": "Sind Sie sicher, dass Sie Ihr Taiga Benutzerkonto löschen wollen?",
             "NEWSLETTER_LABEL_TEXT": "Ich möchte keinen Newsletter mehr erhalten",
-            "CANCEL": "Back to settings",
-            "ACCEPT": "Delete account",
-            "BLOCK_PROJECT": "Note that all the projects you own projects will be <strong>blocked</strong> after you delete your account. If you do want a project blocked, transfer ownership to another member of each project prior to deleting your account.",
-            "SUBTITLE": "Sorry to see you go. We'll be here if you should ever consider us again! :("
+            "CANCEL": "Zurück zu Einstellungen",
+            "ACCEPT": "Benutzerkonto löschen",
+            "BLOCK_PROJECT": "Beachten Sie, dass alle Projekte die Sie besitzen, <strong>gesperrt</ strong> werden, nachdem Sie Ihr Konto gelöscht haben. Wenn Sie möchten, dass Ihre Projekte nicht gesperrt werden, ernennen Sie ein anderes Mitglied zum Projektleiter für jedes Projekt, bevor Sie Ihr Konto löschen.",
+            "SUBTITLE": "Schade, dass du uns verlassen willst. Wir sind hier, falls du uns nochmal suchst. :("
         },
         "DELETE_PROJECT": {
             "TITLE": "Projekt löschen",
@@ -947,24 +948,24 @@
         "CREATE_MEMBER": {
             "PLACEHOLDER_INVITATION_TEXT": "(Optional) Fügen Sie einen persönlichen Text zur Einladung hinzu. Erzählen Sie Ihren neuen Mitgliedern etwas Schönes. ;-)",
             "PLACEHOLDER_TYPE_EMAIL": "Geben Sie eine E-Mail ein",
-            "LIMIT_USERS_WARNING_MESSAGE_FOR_OWNER": "Unfortunately, this project can't have more than <strong>{{maxMembers}}</strong> members.<br> If you would like to increase the current limit, please contact the administrator.",
-            "LIMIT_USERS_WARNING_MESSAGE": "Unfortunately, this project can't have more than <strong>{{maxMembers}}</strong> members."
+            "LIMIT_USERS_WARNING_MESSAGE_FOR_OWNER": "Leider kann dieses Projekt nicht mehr als <strong>{{maxMembers}}</strong> Mitglieder haben. Wenn Sie die derzeitige Grenze erhöhen möchten, kontaktieren Sie den Administrator.",
+            "LIMIT_USERS_WARNING_MESSAGE": "Leider kann dieses Projekt nicht mehr als <strong>{{maxMembers}}</strong> Mitglieder haben."
         },
         "LEAVE_PROJECT_WARNING": {
-            "TITLE": "Unfortunately, this project can't be left without an owner",
+            "TITLE": "Das Projekt kann nicht ohne einen Projektleiter existieren.",
             "CURRENT_USER_OWNER": {
-                "DESC": "You are the current owner of this project. Before leaving, please transfer ownership to someone else.",
-                "BUTTON": "Change the project owner"
+                "DESC": "Du bist der aktuelle Besitzer dieses Projektes. Bitte übertrage den Besitzerstatus an jemand anderes bevor du das Projekt verlässt.",
+                "BUTTON": "Projektleiter wechseln"
             },
             "OTHER_USER_OWNER": {
-                "DESC": "Unfortunately, you can't delete a member who is also the current project owner. First, please assign a new project owner.",
-                "BUTTON": "Request project owner change"
+                "DESC": "Leider können Sie das Mitglied nicht löschen, da es der derzeitige Projektleiter ist. Bitte ordnen Sie dem Projekt zuerst einen neuen Projektleiter zu.",
+                "BUTTON": "Antrag Projektleiter-Wechsel "
             }
         },
         "CHANGE_OWNER": {
-            "TITLE": "Who do you want to be the new project owner?",
-            "ADD_COMMENT": "Add comment",
-            "BUTTON": "Ask this project member to become the new project owner"
+            "TITLE": "Wen möchtest du zum neuen Projektleiter ernennen?",
+            "ADD_COMMENT": "Kommentar hinzufügen",
+            "BUTTON": "Fragen Sie dieses Projektmitglied, um Projektleiter zu werden"
         }
     },
     "US": {
@@ -1394,16 +1395,16 @@
     "WIZARD": {
         "SECTION_TITLE_CREATE_PROJECT": "Projekt erstellen",
         "CREATE_PROJECT_TEXT": "Frisch und sauber. Wie aufregend!",
-        "CHOOSE_TEMPLATE": "Which template fits your project best?",
-        "CHOOSE_TEMPLATE_TITLE": "More info about project templates",
-        "CHOOSE_TEMPLATE_INFO": "More info",
-        "PROJECT_DETAILS": "Project Details",
-        "PUBLIC_PROJECT": "Public Project",
-        "PRIVATE_PROJECT": "Private Project",
+        "CHOOSE_TEMPLATE": "Welches Template passt am besten zu Ihrem Projekt?",
+        "CHOOSE_TEMPLATE_TITLE": "Mehr Infos über Projekt-Templates",
+        "CHOOSE_TEMPLATE_INFO": "Weitere Infos",
+        "PROJECT_DETAILS": "Projekt Details",
+        "PUBLIC_PROJECT": "Öffentliches Projekt",
+        "PRIVATE_PROJECT": "Privates Projekt",
         "CREATE_PROJECT": "Projekt anlegen",
-        "MAX_PRIVATE_PROJECTS": "You've reached the maximum number of private projects",
+        "MAX_PRIVATE_PROJECTS": "Sie haben die maximale Anzahl privater Projekte erreicht",
         "MAX_PUBLIC_PROJECTS": "Unfortunately, you've reached the maximum number of public projects",
-        "CHANGE_PLANS": "change plans"
+        "CHANGE_PLANS": "Änderungs-Pläne"
     },
     "WIKI": {
         "PAGE_TITLE": "{{wikiPageName}} - Wiki - {{projectName}}",
@@ -1412,7 +1413,7 @@
         "PLACEHOLDER_PAGE": "Schreiben Sie Ihre Wiki Seite",
         "REMOVE": "Diese Wiki Seite entfernen",
         "DELETE_LIGHTBOX_TITLE": "Wiki Seite löschen",
-        "DELETE_LINK_TITLE": "Delete Wiki link",
+        "DELETE_LINK_TITLE": "Entferne Wiki Link",
         "NAVIGATION": {
             "SECTION_NAME": "Links",
             "ACTION_ADD_LINK": "Link hinzufügen"

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "This value seems to be invalid.",
             "TYPE_EMAIL": "This value should be a valid email.",

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -1113,6 +1113,7 @@
         },
         "SUMMARY": {
             "PROJECT_POINTS": "project<br />points",
+            "TAGS_POINTS":"points<br />in tag filter",
             "DEFINED_POINTS": "defined<br />points",
             "CLOSED_POINTS": "closed<br />points",
             "POINTS_PER_SPRINT": "points /<br />sprint"
@@ -1385,7 +1386,7 @@
             "USERNAME": "Username",
             "EMAIL": "Email",
             "FULL_NAME": "Full name",
-            "PLACEHOLDER_FULL_NAME": "Set your full name (ex. Íñigo Montoya)",
+            "PLACEHOLDER_FULL_NAME": "Set your full name (ex. Ýñigo Montoya)",
             "BIO": "Bio (max. 210 chars)",
             "PLACEHOLDER_BIO": "Tell us something about you",
             "LANGUAGE": "Language",

--- a/app/locales/taiga/locale-es.json
+++ b/app/locales/taiga/locale-es.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Requerimiento del equipo es un nuevo requisito que debe existir en el proyecto pero que no conllevará ningún coste para el cliente.",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Este valor parece inválido.",
             "TYPE_EMAIL": "El valor debe ser un email.",

--- a/app/locales/taiga/locale-es.json
+++ b/app/locales/taiga/locale-es.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Tu texto aquí...",
             "PREVIEW_BUTTON": "Previsualizar",
             "EDIT_BUTTON": "Editar",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Ayuda de sintaxis Markdown"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/locales/taiga/locale-fi.json
+++ b/app/locales/taiga/locale-fi.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Kirjoita tänne...",
             "PREVIEW_BUTTON": "Esikatselu",
             "EDIT_BUTTON": "Muokkaa",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Merkintätavan ohjeet"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/locales/taiga/locale-fi.json
+++ b/app/locales/taiga/locale-fi.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Tämä arvo vaikuttaa virheelliseltä.",
             "TYPE_EMAIL": "Tämän pitäisi olla toimiva sähköpostiosoite.",

--- a/app/locales/taiga/locale-fr.json
+++ b/app/locales/taiga/locale-fr.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Votre texte ici…",
             "PREVIEW_BUTTON": "Aperçu",
             "EDIT_BUTTON": "Modifier",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Aide sur la syntaxe Markdown"
         },
         "PERMISIONS_CATEGORIES": {
@@ -356,7 +357,7 @@
     "HOME": {
         "PAGE_TITLE": "Accueil - Taiga",
         "PAGE_DESCRIPTION": "La page d'accueil de Taiga sur laquelle apparaissent vos projets principaux et toutes les récits utilisateur, tâches et tickets qui vont sont assignés et surveillés.",
-        "EMPTY_WORKING_ON": "<strong>It feels empty, doesn't it?</strong> Start working with Taiga and you'll see here the stories, tasks and issues you are working on.",
+        "EMPTY_WORKING_ON": "<strong>Ça fait vide, hein ?</strong>Commencez à utiliser Taiga et vous verrez apparaître ici les récits, tâches et tickets sur lesquels vous travaillez.",
         "EMPTY_WATCHING": "<strong>Suivez</strong> des récits utilisateur, des tâches, des tickets dans vos projets et soyez prévenu des modifications :)",
         "EMPTY_PROJECT_LIST": "Vous n'avez aucun projet pour l'instant",
         "WORKING_ON_SECTION": "Projets en cours",
@@ -411,8 +412,8 @@
             "PAGE_TITLE": "Membres - {{projectName}}",
             "ADD_BUTTON": "+ Nouveau membre",
             "ADD_BUTTON_TITLE": "Ajouter un membre",
-            "LIMIT_USERS_WARNING_MESSAGE_FOR_ADMIN": "Unfortunately, this project has reached its limit of <strong>({{members}})</strong> allowed members.",
-            "LIMIT_USERS_WARNING_MESSAGE_FOR_OWNER": "This project has reached its limit of <strong>({{members}})</strong> allowed members. If you would like to increase that limit please contact the administrator."
+            "LIMIT_USERS_WARNING_MESSAGE_FOR_ADMIN": "Désolé, ce projet a atteint sa limite de membres autorisés <strong>({{members}})</strong>.",
+            "LIMIT_USERS_WARNING_MESSAGE_FOR_OWNER": "Ce projet a atteint sa limite de  <strong>({{members}})</strong> membres autorisés. Si vous désirez augmenter cette limite, merci de contacter l'administrateur."
         },
         "PROJECT_EXPORT": {
             "TITLE": "Exporter",
@@ -447,7 +448,7 @@
             "MEETUP": "Meet Up",
             "MEETUP_DESCRIPTION": "Choisissez un système de vidéoconférence",
             "SELECT_VIDEOCONFERENCE": "Choisissez un système de vidéoconférence",
-            "SALT_CHAT_ROOM": "Add a prefix to the chatroom name",
+            "SALT_CHAT_ROOM": "Ajouter un préfixe au nom du salon de chat",
             "JITSI_CHAT_ROOM": "Jitsi",
             "APPEARIN_CHAT_ROOM": "AppearIn",
             "TALKY_CHAT_ROOM": "Talky",
@@ -471,10 +472,10 @@
             "LOGO_HELP": "L'image va être agrandie à 80x80px",
             "CHANGE_LOGO": "Changer le logo",
             "ACTION_USE_DEFAULT_LOGO": "Utiliser l'image par défaut",
-            "MAX_PRIVATE_PROJECTS": "You've reached the maximum number of private projects allowed by your current plan",
-            "MAX_PRIVATE_PROJECTS_MEMBERS": "The maximum number of members for private projects has been exceeded",
-            "MAX_PUBLIC_PROJECTS": "Unfortunately, you've reached the maximum number of public projects allowed by your current plan",
-            "MAX_PUBLIC_PROJECTS_MEMBERS": "The project exceeds your maximum number of members for public projects",
+            "MAX_PRIVATE_PROJECTS": "Vous avez atteint le nombre maximum autorisé de projets privés accordé par votre souscription actuelle.",
+            "MAX_PRIVATE_PROJECTS_MEMBERS": "Le nombre maximum de membres de projets privés a été dépassé.",
+            "MAX_PUBLIC_PROJECTS": "Désolé, vous avez atteint le nombre maximum de projets publics accordé par votre souscription actuelle.",
+            "MAX_PUBLIC_PROJECTS_MEMBERS": "Ce projet dépasse le nombre maximum de membres autorisés pour un projet public",
             "PROJECT_OWNER": "Propriétaire du projet",
             "REQUEST_OWNERSHIP": "Demander la propriété",
             "REQUEST_OWNERSHIP_CONFIRMATION_TITLE": "Voulez-vous devenir le nouveau propriétaire du projet ?",
@@ -702,11 +703,11 @@
             "ADD_COMMENT": "Voulez-vous ajouter un commentaire pour le propriétaire du projet ?",
             "UNLIMITED_PROJECTS": "Illimité",
             "OWNER_MESSAGE": {
-                "PRIVATE": "Please remember that you can own up to <strong>{{maxProjects}}</strong> private projects. You currently own <strong>{{currentProjects}}</strong> private projects",
-                "PUBLIC": "Please remember that you can own up to <strong>{{maxProjects}}</strong> public projects. You currently own <strong>{{currentProjects}}</strong> public projects"
+                "PRIVATE": "Gardez en mémoire que vous pouvez posséder jusqu'à <strong>{{maxProjects}}</strong> projets privés. Vous possédez actuellement <strong>{{currentProjects}}</strong> projets privés.",
+                "PUBLIC": "Gardez en mémoire que vous pouvez posséder jusqu'à <strong>{{maxProjects}}</strong> projets publics. Vous possédez actuellement <strong>{{currentProjects}}</strong> projets publics."
             },
             "CANT_BE_OWNED": "Pour le moment, vous ne pouvez devenir propriétaire d'un projet de ce type. Si vous voulez devenir propriétaire de ce projet, merci de contacter l'administrateur afin qu'il puisse modifier les paramètres de votre compte pour autoriser la propriété de projet.",
-            "CHANGE_MY_PLAN": "Change my plan"
+            "CHANGE_MY_PLAN": "Changer ma souscription actuelle"
         }
     },
     "USER": {
@@ -835,28 +836,28 @@
             "ERROR_MAX_SIZE_EXCEEDED": "'{{fileName}}' ({{fileSize}}) est un peu trop lourd pour nos Oompa Loompas, réessayez avec un fichier d'une taille inférieure à ({{maxFileSize}})",
             "SYNC_SUCCESS": "Votre projet a été importé avec succès",
             "PROJECT_RESTRICTIONS": {
-                "PROJECT_MEMBERS_DESC": "The project you are trying to import has {{members}} members, unfortunately, your current plan allows for a maximum of {{max_memberships}} members per project. If you would like to increase that limit please contact the administrator.",
+                "PROJECT_MEMBERS_DESC": "Le projet que vous voulez importer a {{members}} membres. Votre souscription actuelle vous permet un maximum de {{max_memberships}} membres par projet. Si vous désirez augmenter cette limite, merci de contacter un administrateur.",
                 "PRIVATE_PROJECTS_SPACE": {
-                    "TITLE": "Unfortunately, your current plan does not allow for additional private projects",
-                    "DESC": "The project you are trying to import is private. Unfortunately, your current plan does not allow for additional private projects."
+                    "TITLE": "Malheureusement, votre souscription actuelle ne vous permet pas d'ajouter un projet privé supplémentaire.",
+                    "DESC": "Le projet que vous voulez importer est privé. Votre souscription actuelle ne vous permet pas d'ajouter un projet privé supplémentaire."
                 },
                 "PUBLIC_PROJECTS_SPACE": {
-                    "TITLE": "Unfortunately, your current plan does not allow for additional public projects",
-                    "DESC": "The project you are trying to import is public. Unfortunately, your current plan does not allow additional public projects."
+                    "TITLE": "Malheureusement, votre souscription actuelle ne vous permet pas d'ajouter un projet public supplémentaire.",
+                    "DESC": "Le projet que vous voulez importer est privé. Votre souscription actuelle ne vous permet pas d'ajouter un projet public supplémentaire."
                 },
                 "PRIVATE_PROJECTS_MEMBERS": {
-                    "TITLE": "Your current plan allows for a maximum of {{max_memberships}} members per private project"
+                    "TITLE": "Votre souscription actuelle permet un maximum de {{max_memberships}} par projet privé."
                 },
                 "PUBLIC_PROJECTS_MEMBERS": {
-                    "TITLE": "Your current plan allows for a maximum of {{max_memberships}} members per public project."
+                    "TITLE": "Votre souscription actuelle permet un maximum de {{max_memberships}} par projet public."
                 },
                 "PRIVATE_PROJECTS_SPACE_MEMBERS": {
-                    "TITLE": "Unfortunately your current plan doesn't allow additional private projects or an increase of more than {{max_memberships}} members per private project",
-                    "DESC": "The project that you are trying to import is private and has {{members}} members."
+                    "TITLE": "Désolé, votre souscription actuelle ne permet ni d'ajouter des projets privés supplémentaire, ni d'avoir plus de  {{max_memberships}} membres par projet privé.",
+                    "DESC": "Le projet que vous voulez importer est privé et a {{members}} membres."
                 },
                 "PUBLIC_PROJECTS_SPACE_MEMBERS": {
-                    "TITLE": "Unfortunately your current plan doesn't allow additional public projects or an increase of more than {{max_memberships}} members per public project",
-                    "DESC": "The project that you are trying to import is public and has more than {{members}} members."
+                    "TITLE": "Désolé, votre souscription actuelle ne permet ni d'ajouter des projets publics supplémentaire, ni d'avoir plus de  {{max_memberships}} membres par projet public.",
+                    "DESC": "Le projet que vous voulez importer est public et a {{members}} membres."
                 }
             }
         },
@@ -890,7 +891,7 @@
             "CANCEL": "Retour aux réglages",
             "ACCEPT": "Supprimer le compte",
             "BLOCK_PROJECT": "Notez que tous les projets dont vous avez la propriété seront <strong>bloqués</strong> après que vous ayez supprimé votre compte. Si vous souhaitez pas qu'un projet soit bloqué, merci d'en transférer la propriété auprès d'un autre membre avant la suppression de votre compte.",
-            "SUBTITLE": "Sorry to see you go. We'll be here if you should ever consider us again! :("
+            "SUBTITLE": "Vous partez déjà ? Nous serons toujours là si jamais vous changez d'avis ! :("
         },
         "DELETE_PROJECT": {
             "TITLE": "Supprimer le projet",
@@ -947,8 +948,8 @@
         "CREATE_MEMBER": {
             "PLACEHOLDER_INVITATION_TEXT": "(Optionnel) Ajoutez un texte personnalisé à l'invitation. Dites quelque chose de gentil à vos nouveaux membres ;-)",
             "PLACEHOLDER_TYPE_EMAIL": "Saisissez une adresse courriel",
-            "LIMIT_USERS_WARNING_MESSAGE_FOR_OWNER": "Unfortunately, this project can't have more than <strong>{{maxMembers}}</strong> members.<br> If you would like to increase the current limit, please contact the administrator.",
-            "LIMIT_USERS_WARNING_MESSAGE": "Unfortunately, this project can't have more than <strong>{{maxMembers}}</strong> members."
+            "LIMIT_USERS_WARNING_MESSAGE_FOR_OWNER": "Désolé, ce projet ne peut avoir plus de <strong>{{maxMembers}}</strong> membres. <br>Si vous désirez augmenter cette limite, merci de contacter l'administrateur.",
+            "LIMIT_USERS_WARNING_MESSAGE": "Désolé, ce projet ne peut avoir plus de <strong>{{maxMembers}}</strong> membres."
         },
         "LEAVE_PROJECT_WARNING": {
             "TITLE": "Malheureusement, ce projet ne peut pas être laissé sans propriétaire",
@@ -1402,7 +1403,7 @@
         "PRIVATE_PROJECT": "Projet privé",
         "CREATE_PROJECT": "Créer un projet",
         "MAX_PRIVATE_PROJECTS": "Vous avez atteint le nombre maximum de projets privés",
-        "MAX_PUBLIC_PROJECTS": "Unfortunately, you've reached the maximum number of public projects",
+        "MAX_PUBLIC_PROJECTS": "Désolé, vous avez atteint le nombre maximal de projet public.",
         "CHANGE_PLANS": "changer de souscription"
     },
     "WIKI": {
@@ -1412,7 +1413,7 @@
         "PLACEHOLDER_PAGE": "Ecrivez votre page wiki",
         "REMOVE": "Supprimer cette page wiki",
         "DELETE_LIGHTBOX_TITLE": "Supprimer la page Wiki",
-        "DELETE_LINK_TITLE": "Delete Wiki link",
+        "DELETE_LINK_TITLE": "Supprimer un lien Wiki",
         "NAVIGATION": {
             "SECTION_NAME": "Liens",
             "ACTION_ADD_LINK": "Ajouter un lien"

--- a/app/locales/taiga/locale-fr.json
+++ b/app/locales/taiga/locale-fr.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Un besoin projet est un besoin qui est nécessaire au projet mais qui ne doit avoir aucun impact pour le client",
         "OWNER": "Propriétaire du Projet",
         "CAPSLOCK_WARNING": "Attention ! Vous utilisez des majuscules dans un champ qui est sensible à la casse.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Cette valeur semble être invalide.",
             "TYPE_EMAIL": "Cette valeur devrait être une adresse courriel valide.",

--- a/app/locales/taiga/locale-it.json
+++ b/app/locales/taiga/locale-it.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Inserire qui il testo...",
             "PREVIEW_BUTTON": "Anteprima",
             "EDIT_BUTTON": "Modifica",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Aiuto per la sintassi Markdown"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/locales/taiga/locale-it.json
+++ b/app/locales/taiga/locale-it.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Requisito del Team è un requisito che deve esistere nel progetto ma non deve avere costi per il cliente",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Questo valore non è valido.",
             "TYPE_EMAIL": "Questo valore dovrebbe corrispondere ad una mail valida",

--- a/app/locales/taiga/locale-nl.json
+++ b/app/locales/taiga/locale-nl.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Deze waarde lijkt ongeldig te zijn",
             "TYPE_EMAIL": "Deze waarde moet een geldig emailadres bevatten",

--- a/app/locales/taiga/locale-nl.json
+++ b/app/locales/taiga/locale-nl.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Je tekst hier...",
             "PREVIEW_BUTTON": "Voorbeeld",
             "EDIT_BUTTON": "Bewerk",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Markdown syntax help"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/locales/taiga/locale-pl.json
+++ b/app/locales/taiga/locale-pl.json
@@ -2,7 +2,7 @@
     "COMMON": {
         "YES": "Tak",
         "NO": "Nie",
-        "OR": "or",
+        "OR": "lub",
         "LOADING": "Wczytywanie...",
         "LOADING_PROJECT": "Wczytywanie projektu...",
         "DATE": "DD MMM YYYY",
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Przykładowy tekst...",
             "PREVIEW_BUTTON": "Podgląd",
             "EDIT_BUTTON": "Edycja",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Składnia Markdown pomoc"
         },
         "PERMISIONS_CATEGORIES": {
@@ -286,9 +287,9 @@
         "HEADER": "Mam już login do Taigi",
         "PLACEHOLDER_AUTH_NAME": "Login albo e-mail (uwzględnij wielkość liter)",
         "LINK_FORGOT_PASSWORD": "Zapomniałeś?",
-        "TITLE_LINK_FORGOT_PASSWORD": "Did you forget your password?",
+        "TITLE_LINK_FORGOT_PASSWORD": "Zapomniałeś hasło? ",
         "ACTION_ENTER": "Wprowadź",
-        "ACTION_SIGN_IN": "Login",
+        "ACTION_SIGN_IN": "Zaloguj",
         "PLACEHOLDER_AUTH_PASSWORD": "Hasło (uwzględnij wielkość liter)"
     },
     "LOGIN_FORM": {
@@ -319,8 +320,8 @@
         "PLACEHOLDER_FIELD": "Login albo e-mail",
         "ACTION_RESET_PASSWORD": "Resetuj hasło",
         "LINK_CANCEL": "Nie, zabierz mnie stąd. Chyba je pamiętam.",
-        "SUCCESS_TITLE": "Check your inbox!",
-        "SUCCESS_TEXT": "We sent you an email with the instructions to set a new password",
+        "SUCCESS_TITLE": "Sprawdź swoją skrzynkę mailową!",
+        "SUCCESS_TEXT": "Sprawdź swoją skrzynkę!<br />Wysłaliśmy Ci wiadomość e-mail z instrukcją jak ustawić nowe hasło.",
         "ERROR": "Nasze Umpa Lumpy twierdzą, że nie jesteś jeszcze zarejestrowany."
     },
     "CHANGE_PASSWORD": {
@@ -349,7 +350,7 @@
         "PAGE_DESCRIPTION": "Zaakceptuj zaproszenie, aby dołączyć do projektu w Taiga, platformie do zarządzania projektami dla startup'ów i zwinnych deweloperów oraz designerów, którzy chcą prostego, pięknego narzędzia sprawiającego, że praca jest przyjemna."
     },
     "INVITATION_LOGIN_FORM": {
-        "NOT_FOUND": "Our Oompa Loompas can't find your invitation.",
+        "NOT_FOUND": "Nasze Umpa Lumpy nie znajdują Twojego zaproszenia :(",
         "SUCCESS": "Udało Ci się dołączyć do tego projektu. Witaj w {{project_name}}",
         "ERROR": "Według naszych Umpa Lump, nie jesteś jeszcze zarejestrowany. Albo wpisałeś złe hasło."
     },

--- a/app/locales/taiga/locale-pl.json
+++ b/app/locales/taiga/locale-pl.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Nieprawidłowa wartość",
             "TYPE_EMAIL": "Podaj prawidłowy adres email.",

--- a/app/locales/taiga/locale-pt-br.json
+++ b/app/locales/taiga/locale-pt-br.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Requisito de time é um requisito que deve existir no projeto, mas que não deve ter nenhum custo para o cliente.",
         "OWNER": "Dono do Projeto",
         "CAPSLOCK_WARNING": "Seja cuidadoso! Você está escrevendo em letras maiúsculas e esse campo é case sensitive, ou seja, trata com distinção as letras maiúsculas das minúsculas.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Este valor parece ser inválido.",
             "TYPE_EMAIL": "Este valor deve ser um e-mail válido.",

--- a/app/locales/taiga/locale-pt-br.json
+++ b/app/locales/taiga/locale-pt-br.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Seu texto aqui...",
             "PREVIEW_BUTTON": "Pré Visualizar",
             "EDIT_BUTTON": "Editar",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Ajuda de sintaxe markdown"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/locales/taiga/locale-pt-br.json
+++ b/app/locales/taiga/locale-pt-br.json
@@ -39,10 +39,10 @@
         "EXTERNAL_USER": "um usuário externo",
         "GENERIC_ERROR": "Um Oompa Loompas disse {{error}}.",
         "IOCAINE_TEXT": "Se sentindo sobrecarregado por uma tarefa? Assegure-se de que os outros saibam disso clicando em Iocaine quando estiver editando a tarefa. É possível se tornar imune a essse veneno mortal (fictício) consumindo pequenas quantidades ao longo do tempo, assim como é possível ficar melhor no que faz, ocasionalmente, por assumir desafios extras!",
-        "CLIENT_REQUIREMENT": "Client requirement is new requirement that was not previously expected and it is required to be part of the project",
-        "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
+        "CLIENT_REQUIREMENT": "Requisito de cliente é um novo requisito que não foi anteriormente previsto e que necessita se tornar uma parte do projeto.",
+        "TEAM_REQUIREMENT": "Requisito de time é um requisito que deve existir no projeto, mas que não deve ter nenhum custo para o cliente.",
         "OWNER": "Dono do Projeto",
-        "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CAPSLOCK_WARNING": "Seja cuidadoso! Você está escrevendo em letras maiúsculas e esse campo é case sensitive, ou seja, trata com distinção as letras maiúsculas das minúsculas.",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Este valor parece ser inválido.",
             "TYPE_EMAIL": "Este valor deve ser um e-mail válido.",
@@ -68,7 +68,7 @@
             "RANGE_CHECK": "Você deve selecionar entre %s e %s escolhas.",
             "EQUAL_TO": "Esse valor deveria ser o mesmo.",
             "LINEWIDTH": "One or more lines is perhaps too long. Try to keep under %s characters.",
-            "PIKADAY": "Invalid date format, please use DD MMM YYYY (like 23 Mar 1984)"
+            "PIKADAY": "Formato de data inválido, por favor, use DD MMM YYYY (exemplo: 23 Mar 1984)"
         },
         "PICKERDATE": {
             "FORMAT": "DD MMM YYYY",
@@ -110,16 +110,16 @@
             }
         },
         "SEE_USER_PROFILE": "Ver o perfil de {{username }}",
-        "USER_STORY": "User Story",
+        "USER_STORY": "História de usuário",
         "TASK": "Tarefa",
-        "ISSUE": "Caso",
+        "ISSUE": "Problema",
         "TAGS": {
-            "PLACEHOLDER": "To dentro! Me tagueie....",
+            "PLACEHOLDER": "Adicionar tags...",
             "DELETE": "Apagar tag",
             "ADD": "Adicionar tag"
         },
         "DESCRIPTION": {
-            "EMPTY": "Espaço vazio é tãããooo monótono... escreva algo, vai...",
+            "EMPTY": "Espaço vazio é tão monótono... escreva algo, vai...",
             "NO_DESCRIPTION": "Sem descrição ainda"
         },
         "FIELDS": {
@@ -131,9 +131,9 @@
             "SLUG": "Rótulo",
             "COLOR": "Cor",
             "IS_CLOSED": "Está fechado?",
-            "STATUS": "Situação",
+            "STATUS": "Status",
             "TYPE": "Tipo",
-            "SEVERITY": "Severidade",
+            "SEVERITY": "Gravidade",
             "PRIORITY": "Prioridade",
             "ASSIGNED_TO": "Atribuído a",
             "POINTS": "Pontos",
@@ -173,7 +173,7 @@
             "UNWATCH": "Deixar de Observar",
             "WATCHERS": "Observadores",
             "BUTTON_TITLE": "Observar/Deixar de observar este item",
-            "COUNTER_TITLE": "{total, plural, um{um observador} outro{#watchers}}"
+            "COUNTER_TITLE": "{total, plural, one{um observador} other{#watchers}}"
         },
         "VOTE_BUTTON": {
             "UPVOTE": "Aprovar",
@@ -181,7 +181,7 @@
             "DOWNVOTE": "Reprovar",
             "VOTERS": "Eleitores",
             "BUTTON_TITLE": "Aprovar/Reprovar este item",
-            "COUNTER_TITLE": "{total, plural, um{um voto} outro{# votos}}"
+            "COUNTER_TITLE": "{total, plural, one{um voto} other{# votos}}"
         },
         "CUSTOM_ATTRIBUTES": {
             "CUSTOM_FIELDS": "Campos Personalizados",
@@ -196,7 +196,7 @@
             "TITLE_ACTION_FILTER_BUTTON": "procurar",
             "BREADCRUMB_TITLE": "voltar para categorias",
             "BREADCRUMB_FILTERS": "Filtros",
-            "BREADCRUMB_STATUS": "Situação"
+            "BREADCRUMB_STATUS": "status"
         },
         "WYSIWYG": {
             "H1_BUTTON": "Primeira caixa de cabeçalho",
@@ -225,7 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Seu texto aqui...",
             "PREVIEW_BUTTON": "Pré Visualizar",
             "EDIT_BUTTON": "Editar",
-            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
+            "ATTACH_FILE_HELP": "Anexe arquivos arrastando e soltando na área de texto acima.",
             "MARKDOWN_HELP": "Ajuda de sintaxe markdown"
         },
         "PERMISIONS_CATEGORIES": {
@@ -237,11 +237,11 @@
                 "DELETE_SPRINTS": "Apagar sprints"
             },
             "USER_STORIES": {
-                "NAME": "User Stories",
-                "VIEW_USER_STORIES": "Ver user stories",
-                "ADD_USER_STORIES": "Adicionar user stories",
-                "MODIFY_USER_STORIES": "Modificar estórias de usuário",
-                "DELETE_USER_STORIES": "Apagar user stories"
+                "NAME": "Histórias de Usuários",
+                "VIEW_USER_STORIES": "Ver histórias de usuários",
+                "ADD_USER_STORIES": "Adicionar histórias de usuários",
+                "MODIFY_USER_STORIES": "Modificar histórias de usuários",
+                "DELETE_USER_STORIES": "Apagar histórias de usuários"
             },
             "TASKS": {
                 "NAME": "Tarefas",
@@ -251,11 +251,11 @@
                 "DELETE_TASKS": "Apagar tarefas"
             },
             "ISSUES": {
-                "NAME": "Casos",
-                "VIEW_ISSUES": "Ver casos",
-                "ADD_ISSUES": "Adicionar casos",
-                "MODIFY_ISSUES": "Modificar casos",
-                "DELETE_ISSUES": "Apagar casos"
+                "NAME": "Problemas",
+                "VIEW_ISSUES": "Ver problemas",
+                "ADD_ISSUES": "Adicionar problemas",
+                "MODIFY_ISSUES": "Modificar problemas",
+                "DELETE_ISSUES": "Apagar problemas"
             },
             "WIKI": {
                 "NAME": "Wiki",
@@ -356,9 +356,9 @@
     },
     "HOME": {
         "PAGE_TITLE": "Início - Taiga",
-        "PAGE_DESCRIPTION": "A página inicial do Taiga com seus principais projetos e todas as estórias atribuídas ou observadas por você, tarefas e problemas",
-        "EMPTY_WORKING_ON": "<strong>It feels empty, doesn't it?</strong> Start working with Taiga and you'll see here the stories, tasks and issues you are working on.",
-        "EMPTY_WATCHING": "<strong>Siga</strong> Estórias, Tarefas e Casos nos seus projetos e seja notificado das mudanças :)",
+        "PAGE_DESCRIPTION": "A página inicial do Taiga com seus principais projetos e todas as histórias de usuários atribuídas ou observadas por você, tarefas e problemas",
+        "EMPTY_WORKING_ON": "<strong>Parece vazio, não acha?</strong> Comece a trabalhar com Taiga e você verá aqui as histórias, tarefas e problemas em que está trabalhando.",
+        "EMPTY_WATCHING": "<strong>Siga</strong> Histórias de Usuários, Tarefas e Problemas nos seus projetos e seja notificado das mudanças :)",
         "EMPTY_PROJECT_LIST": "Você ainda não tem projetos",
         "WORKING_ON_SECTION": "Trabalhando em",
         "WATCHING_SECTION": "Observando",
@@ -434,20 +434,20 @@
             "ENABLE": "Habilitar",
             "DISABLE": "Desabilitar",
             "BACKLOG": "Backlog",
-            "BACKLOG_DESCRIPTION": "Gerencie suas user stories para manter uma visualização organizada de trabalhos futuros e priorizados.",
-            "NUMBER_SPRINTS": "Expected number of sprints",
-            "NUMBER_SPRINTS_HELP": "0 for an undetermined number",
-            "NUMBER_US_POINTS": "Expected total of story points",
-            "NUMBER_US_POINTS_HELP": "0 for an undetermined number",
+            "BACKLOG_DESCRIPTION": "Gerencie suas histórias de usuários para manter uma visualização organizada de trabalhos futuros e priorizados.",
+            "NUMBER_SPRINTS": "Número de sprints esperadas",
+            "NUMBER_SPRINTS_HELP": "0 para um número indeterminado",
+            "NUMBER_US_POINTS": "Total esperado de pontos de história",
+            "NUMBER_US_POINTS_HELP": "0 para um número indeterminado",
             "KANBAN": "Kanban",
             "KANBAN_DESCRIPTION": "Organize seu projeto de um jeito \"lean\" com esse mural",
             "ISSUES": "Problemas",
-            "ISSUES_DESCRIPTION": "Acompanhe os bugs, questões e melhorias relacionadas ao seu projeto. Não perca nada!",
+            "ISSUES_DESCRIPTION": "Acompanhe os bugs, problemas e melhorias relacionados ao seu projeto. Não perca nada!",
             "WIKI": "Wiki",
             "WIKI_DESCRIPTION": "Adicione, modifique ou apague conteúdo em colaboração com outras pessoas. Este é o local certo pra documentação do seu projeto.",
             "MEETUP": "Reunião",
-            "MEETUP_DESCRIPTION": "Choose your videoconference system.",
-            "SELECT_VIDEOCONFERENCE": "Selecione um sistema de video conferência",
+            "MEETUP_DESCRIPTION": "Selecione seu sistema de videoconferência.",
+            "SELECT_VIDEOCONFERENCE": "Selecione um sistema de videoconferência",
             "SALT_CHAT_ROOM": "Add a prefix to the chatroom name",
             "JITSI_CHAT_ROOM": "Jitsi",
             "APPEARIN_CHAT_ROOM": "AppearIn",
@@ -476,10 +476,10 @@
             "MAX_PRIVATE_PROJECTS_MEMBERS": "The maximum number of members for private projects has been exceeded",
             "MAX_PUBLIC_PROJECTS": "Unfortunately, you've reached the maximum number of public projects allowed by your current plan",
             "MAX_PUBLIC_PROJECTS_MEMBERS": "The project exceeds your maximum number of members for public projects",
-            "PROJECT_OWNER": "Project owner",
-            "REQUEST_OWNERSHIP": "Request ownership",
+            "PROJECT_OWNER": "Dono do projeto",
+            "REQUEST_OWNERSHIP": "Solicitar propriedade",
             "REQUEST_OWNERSHIP_CONFIRMATION_TITLE": "Gostaria de se tornar o novo dono do projeto?",
-            "REQUEST_OWNERSHIP_DESC": "Request that current project owner {{name}} transfer ownership of this project to you.",
+            "REQUEST_OWNERSHIP_DESC": "Solicitar ao atual dono de projeto {{name}} a transferência da propriedade deste projeto para você.",
             "REQUEST_OWNERSHIP_BUTTON": "Solicitação",
             "REQUEST_OWNERSHIP_SUCCESS": "We'll notify the project owner",
             "CHANGE_OWNER": "Change owner",
@@ -495,7 +495,7 @@
             "REGENERATE_SUBTITLE": "Você está prestes a alterar a url de acesso a dados do CSV. A URL anterior será desabilitada. Você está certo disso?"
         },
         "CSV": {
-            "SECTION_TITLE_US": "Relatórios de user stories",
+            "SECTION_TITLE_US": "Relatórios de histórias de usuários",
             "SECTION_TITLE_TASK": "relatórios de tarefas",
             "SECTION_TITLE_ISSUE": "relatórios de problemas",
             "DOWNLOAD": "Baixar CSV",
@@ -506,13 +506,13 @@
         },
         "CUSTOM_FIELDS": {
             "TITLE": "Campos Personalizados",
-            "SUBTITLE": "Especificar campos personalizados para estórias, tarefas e problemas",
-            "US_DESCRIPTION": "Campos personalizados das user stories",
-            "US_ADD": "Adicionar campo personalizado nas user stories",
-            "TASK_DESCRIPTION": "Campos personalizados das Tarefas\n",
+            "SUBTITLE": "Especificar campos personalizados para histórias de usuários, tarefas e problemas",
+            "US_DESCRIPTION": "Campos personalizados das histórias de usuários",
+            "US_ADD": "Adicionar campo personalizado nas histórias de usuários",
+            "TASK_DESCRIPTION": "Campos personalizados das Tarefas",
             "TASK_ADD": "Adicionar campos personalizados na tarefa",
             "ISSUE_DESCRIPTION": "Campos personalizados dos problemas",
-            "ISSUE_ADD": "Adicionar um campo personalizado no problema",
+            "ISSUE_ADD": "Adicionar um campo personalizado em problemas ",
             "FIELD_TYPE_TEXT": "Texto",
             "FIELD_TYPE_MULTI": "Multi-linha",
             "FIELD_TYPE_DATE": "Data",
@@ -525,8 +525,8 @@
         },
         "PROJECT_VALUES_POINTS": {
             "TITLE": "Pontos",
-            "SUBTITLE": "Especifique os pontos de suas user stories poderiam ser estimados ",
-            "US_TITLE": "Pontos de User Stories",
+            "SUBTITLE": "Especifique os pontos em que suas histórias de usuários poderiam ser estimados ",
+            "US_TITLE": "Pontos de Histórias de Usuários",
             "ACTION_ADD": "Adicionar novo ponto"
         },
         "PROJECT_VALUES_PRIORITIES": {
@@ -536,28 +536,28 @@
             "ACTION_ADD": "Adicionar nova prioridade"
         },
         "PROJECT_VALUES_SEVERITIES": {
-            "TITLE": "Seriedades",
-            "SUBTITLE": "Especifique as severidades que seus problemas terão",
-            "ISSUE_TITLE": "Seriedades do problema",
-            "ACTION_ADD": "Adicionar nova severidade"
+            "TITLE": "Gravidades",
+            "SUBTITLE": "Especifique as gravidades que seus problemas terão",
+            "ISSUE_TITLE": "Gravidades do problema",
+            "ACTION_ADD": "Adicionar nova gravidade"
         },
         "PROJECT_VALUES_STATUS": {
-            "TITLE": "Situação",
-            "SUBTITLE": "Especifique os status pelos quais suas estórias, tarefas e problemas passarão",
-            "US_TITLE": "Estados das Users Strories",
-            "TASK_TITLE": "Estados da tarefa",
-            "ISSUE_TITLE": "Estados do caso"
+            "TITLE": "Status",
+            "SUBTITLE": "Especifique os status pelos quais suas histórias de usuários, tarefas e problemas passarão",
+            "US_TITLE": "Estados das Histórias de Usuários",
+            "TASK_TITLE": "Estados da Tarefa",
+            "ISSUE_TITLE": "Estados do problema"
         },
         "PROJECT_VALUES_TYPES": {
             "TITLE": "Tipos",
-            "SUBTITLE": "Especifique os tipos que seu problema pode ser",
-            "ISSUE_TITLE": "Tipos de casos",
+            "SUBTITLE": "Especifique de que tipos seus problemas poderão ser",
+            "ISSUE_TITLE": "Tipos de problemas",
             "ACTION_ADD": "Adicionar novo {{objName}}"
         },
         "ROLES": {
             "PAGE_TITLE": "Funções - {{projectName}}",
-            "WARNING_NO_ROLE": "Seja cuidadoso, nenhuma função em seu projeto será capaz de estimar o valor dos pontos para as user stories",
-            "HELP_ROLE_ENABLED": "Quando habilitado, membros atribuídos a esta função serão capazes de estimar valores para user stories",
+            "WARNING_NO_ROLE": "Seja cuidadoso, nenhuma função em seu projeto será capaz de estimar o valor dos pontos para as histórias de usuários",
+            "HELP_ROLE_ENABLED": "Quando habilitado, membros atribuídos a esta função serão capazes de estimar valores para histórias de usuários",
             "DISABLE_COMPUTABLE_ALERT_TITLE": "Você tem certeza que quer desativar esta permissão de estimativas?",
             "DISABLE_COMPUTABLE_ALERT_SUBTITLE": "Se você desativar a permissão de estimativas para esta regra  {{roleName}} todas estimativas feitas anteriormente por esta regra serão removidas.",
             "COUNT_MEMBERS": "{{ role.members_count }} membros com a mesma função",
@@ -589,7 +589,7 @@
         "WEBHOOKS": {
             "PAGE_TITLE": "Webhooks - {{projectName}}",
             "SECTION_NAME": "Webhooks",
-            "SUBTITLE": "Webhooks notificam serviços externos sobre eventos no Taiga, como comentários, user stories....",
+            "SUBTITLE": "Webhooks notificam serviços externos sobre eventos no Taiga, como comentários, histórias de usuários...",
             "ADD_NEW": "Adicionar um Novo Webhook",
             "TYPE_NAME": "Digite o nome do serviço",
             "TYPE_PAYLOAD_URL": "Digite a url do serviço Payload",
@@ -606,9 +606,9 @@
             "PAYLOAD": "Payload",
             "RESPONSE": "Resposta",
             "DATE": "DD MMM YYYY [at] hh:mm:ss",
-            "ACTION_HIDE_HISTORY": "(Esconder história)",
+            "ACTION_HIDE_HISTORY": "(Esconder histórico)",
             "ACTION_HIDE_HISTORY_TITLE": "Esconder os detalhes da história",
-            "ACTION_SHOW_HISTORY": "(Mostrar história)",
+            "ACTION_SHOW_HISTORY": "(Mostrar histórico)",
             "ACTION_SHOW_HISTORY_TITLE": "Mostrar detalhes da história",
             "WEBHOOK_NAME": "Webhook '{{name}}'"
         },
@@ -629,7 +629,7 @@
             "COLUMN_MEMBER": "Membro",
             "COLUMN_ADMIN": "Administrador",
             "COLUMN_ROLE": "Função",
-            "COLUMN_STATUS": "Situação",
+            "COLUMN_STATUS": "Status",
             "STATUS_ACTIVE": "Ativo",
             "STATUS_PENDING": "Pendente",
             "DELETE_MEMBER": "Apagar membro",
@@ -642,12 +642,12 @@
         },
         "DEFAULT_VALUES": {
             "LABEL_POINTS": "Valores padrões para o seletor de pontos",
-            "LABEL_US": "Valor padrão para seletor de status da US",
+            "LABEL_US": "Valor padrão para seletor de status da História de Usuário",
             "LABEL_TASK_STATUS": "Valor padrão para seletor de status de tarefa",
             "LABEL_PRIORITY": "Valor padão para seletor de prioridade",
-            "LABEL_SEVERITY": "Valor padrão para seletor de severidade",
-            "LABEL_ISSUE_TYPE": "Valor padrão para seletor de tipo de caso",
-            "LABEL_ISSUE_STATUS": "Valor padrão para seletor de status de caso"
+            "LABEL_SEVERITY": "Valor padrão para seletor de gravidade",
+            "LABEL_ISSUE_TYPE": "Valor padrão para seletor de tipo de problema ",
+            "LABEL_ISSUE_STATUS": "Valor padrão para seletor de status de problema"
         },
         "STATUS": {
             "PLACEHOLDER_WRITE_STATUS_NAME": "Digite um nome para o novo status"
@@ -674,10 +674,10 @@
             "TITLE": "Atributos"
         },
         "SUBMENU_PROJECT_VALUES": {
-            "STATUS": "Situação",
+            "STATUS": "Status",
             "POINTS": "Pontos",
             "PRIORITIES": "Prioridades",
-            "SEVERITIES": "Seriedades",
+            "SEVERITIES": "Gravidades",
             "TYPES": "Tipos",
             "CUSTOM_FIELDS": "Campos personalizados"
         },
@@ -715,7 +715,7 @@
             "PAGE_TITLE": "{{userFullName}} (@{{userUsername}})",
             "EDIT": "Editar Perfil",
             "FOLLOW": "Seguir",
-            "CLOSED_US": "US Fechadas",
+            "CLOSED_US": "Histórias Fechadas",
             "PROJECTS": "Projetos",
             "PROJECTS_EMPTY": "{{username}} ainda não tem projetos",
             "CONTACTS": "Contatos",
@@ -749,8 +749,8 @@
             "FILTER_TYPE_ALL_TITLE": "Mostrar tudo",
             "FILTER_TYPE_PROJECTS": "Projetos",
             "FILTER_TYPE_PROJECT_TITLES": "Mostrar somente projetos",
-            "FILTER_TYPE_USER_STORIES": "Stories",
-            "FILTER_TYPE_USER_STORIES_TITLES": "Mostrar apenas user stories",
+            "FILTER_TYPE_USER_STORIES": "Histórias",
+            "FILTER_TYPE_USER_STORIES_TITLES": "Mostrar apenas histórias de usuários",
             "FILTER_TYPE_TASKS": "Tarefas",
             "FILTER_TYPE_TASK_TITLES": "Mostrar apenas tarefas",
             "FILTER_TYPE_ISSUES": "Problemas",
@@ -765,11 +765,11 @@
         "HELP": "Reordene seus projetos para colocar no topo os mais usados.<br/> Os 10 primeiros projetos aparecerão na lista de projetos da barra de navegação superior.",
         "PRIVATE": "Projeto Privado",
         "LOOKING_FOR_PEOPLE": "Este projeto esta a procura de colaboradores",
-        "FANS_COUNTER_TITLE": "{total, plural, um{um fã} outro{# fãs}}",
-        "WATCHERS_COUNTER_TITLE": "{total, plural, um{um observador} outro{#watchers}}",
-        "MEMBERS_COUNTER_TITLE": "{total, plural, um{one member} outro{# members}}",
+        "FANS_COUNTER_TITLE": "{total, plural, one{um fã} other{# fãs}}",
+        "WATCHERS_COUNTER_TITLE": "{total, plural, one{um observador} other{#watchers}}",
+        "MEMBERS_COUNTER_TITLE": "{total, plural, one{one member} other{# members}}",
         "BLOCKED_PROJECT": {
-            "BLOCKED": "Blocked project",
+            "BLOCKED": "Projeto bloqueado",
             "THIS_PROJECT_IS_BLOCKED": "This project is temporarily blocked",
             "TO_UNBLOCK_CONTACT_THE_ADMIN_STAFF": "In order to unblock your projects, contact the administrator."
         },
@@ -866,13 +866,13 @@
             "LIKED": "Curtiu",
             "UNLIKE": "Descurtir",
             "BUTTON_TITLE": "Curtir ou descurtir este projeto",
-            "COUNTER_TITLE": "{total, plural, um{um fã} outro{# fãs}}"
+            "COUNTER_TITLE": "{total, plural, one{um fã} other{# fãs}}"
         },
         "WATCH_BUTTON": {
             "BUTTON_TITLE": "Observar este projeto e definir política de notificação",
             "WATCH": "Observar",
             "WATCHING": "Observando",
-            "COUNTER_TITLE": "{total, plural, um{um observador} outro{#watchers}}",
+            "COUNTER_TITLE": "{total, plural, one{um observador} other{#watchers}}",
             "OPTIONS": {
                 "NOTIFY_ALL": "receber todas notificações",
                 "NOTIFY_ALL_TITLE": "Receber todas notificações para este projeto",
@@ -891,12 +891,12 @@
             "CANCEL": "Voltar para configurações",
             "ACCEPT": "Remover conta",
             "BLOCK_PROJECT": "Note that all the projects you own projects will be <strong>blocked</strong> after you delete your account. If you do want a project blocked, transfer ownership to another member of each project prior to deleting your account.",
-            "SUBTITLE": "Sorry to see you go. We'll be here if you should ever consider us again! :("
+            "SUBTITLE": "É uma pena vê-lo partir. Estaremos aqui se você algum dia considerar-nos novamente! :("
         },
         "DELETE_PROJECT": {
             "TITLE": "Apagar projeto",
             "QUESTION": "Você tem certeza que quer apagar este projeto?",
-            "SUBTITLE": "Todas as informações do projeto (estórias, tarefas, problemas, sprints e páginas de wiki) serão perdidos! :-(",
+            "SUBTITLE": "Todas as informações do projeto (histórias, tarefas, problemas, sprints e páginas de wiki) serão perdidas! :-(",
             "CONFIRM": "Sim, eu tenho certeza"
         },
         "ASSIGNED_TO": {
@@ -920,27 +920,27 @@
             "PLACEHOLDER_SEARCH": "O que você está procurando?"
         },
         "ADD_EDIT_SPRINT": {
-            "TITLE": "Novo Sprint",
-            "PLACEHOLDER_SPRINT_NAME": "nome do sprint",
+            "TITLE": "Nova Sprint",
+            "PLACEHOLDER_SPRINT_NAME": "nome da sprint",
             "PLACEHOLDER_SPRINT_START": "Inicio Estimado",
             "PLACEHOLDER_SPRINT_END": "Estimativa de Termino",
-            "ACTION_DELETE_SPRINT": "Você quer apagar este sprint?",
+            "ACTION_DELETE_SPRINT": "Você quer apagar esta sprint?",
             "TITLE_ACTION_DELETE_SPRINT": "apagar sprint",
-            "LAST_SPRINT_NAME": "último sprint é <strong>{{lastSprint}} ;-) </strong>"
+            "LAST_SPRINT_NAME": "última sprint é <strong>{{lastSprint}} ;-) </strong>"
         },
         "CREATE_EDIT_TASK": {
             "TITLE": "Nova tarefa",
             "PLACEHOLDER_SUBJECT": "Um assunto da tarefa",
-            "PLACEHOLDER_STATUS": "Situação da Tarefa",
+            "PLACEHOLDER_STATUS": "Status da Tarefa",
             "OPTION_UNASSIGNED": "Não assinalado",
             "PLACEHOLDER_SHORT_DESCRIPTION": "Escreva uma curta descrição",
             "ACTION_EDIT": "Editar tarefa"
         },
         "CREATE_EDIT_US": {
-            "TITLE": "Nova EU",
-            "PLACEHOLDER_DESCRIPTION": "Por favor, adicione um texto descritivo para ajudar outras pessoas a entenderem melhor esta EU",
-            "NEW_US": "Nova user story",
-            "EDIT_US": "Editar user story"
+            "TITLE": "Nova História de Usuário",
+            "PLACEHOLDER_DESCRIPTION": "Por favor, adicione um texto descritivo para ajudar outras pessoas a entenderem melhor esta história de usuário",
+            "NEW_US": "Nova história de usuário",
+            "EDIT_US": "Editar história de usuário"
         },
         "DELETE_SPRINT": {
             "TITLE": "Apagar sprint"
@@ -963,33 +963,33 @@
             }
         },
         "CHANGE_OWNER": {
-            "TITLE": "Who do you want to be the new project owner?",
-            "ADD_COMMENT": "Add comment",
-            "BUTTON": "Ask this project member to become the new project owner"
+            "TITLE": "Quem você quer que seja o novo dono do projeto?",
+            "ADD_COMMENT": "Adicionar comentário",
+            "BUTTON": "Pedir a este membro do projeto para se tornar o novo dono do projeto"
         }
     },
     "US": {
-        "PAGE_TITLE": "{{userStorySubject}} - User Story {{userStoryRef}} - {{projectName}}",
+        "PAGE_TITLE": "{{userStorySubject}} - História de Usuário {{userStoryRef}} - {{projectName}}",
         "PAGE_DESCRIPTION": "Estado: {{userStoryStatus }}. Completos {{userStoryProgressPercentage}}% ({{userStoryClosedTasks}} de {{userStoryTotalTasks}} tarefas encerradas). Pontos: {{userStoryPoints}}. Descrição: {{userStoryDescription}}",
-        "SECTION_NAME": "Detalhes de User Story",
+        "SECTION_NAME": "Detalhes da História de Usuário",
         "LINK_TASKBOARD": "Quadro de Tarefas",
         "TITLE_LINK_TASKBOARD": "Ir para o quadro de tarefas",
         "TOTAL_POINTS": "total de pontos",
-        "ADD": "+ Adicionar uma nova User Story",
-        "ADD_BULK": "Adicionar User Stories em lote",
-        "PROMOTED": "Esta estória de uso foi promovida do problema:",
+        "ADD": "+ Adicionar uma nova História de Usuário",
+        "ADD_BULK": "Adicionar Histórias de Usuários em lote",
+        "PROMOTED": "Esta história de usuário foi promovida do problema:",
         "TITLE_LINK_GO_TO_ISSUE": "Ir para problema",
-        "EXTERNAL_REFERENCE": "Esta EU foi criada de",
+        "EXTERNAL_REFERENCE": "Esta História de Usuário foi criada de",
         "GO_TO_EXTERNAL_REFERENCE": "Ir para a origem",
-        "BLOCKED": "Esta user story está bloqueada",
-        "PREVIOUS": "user story anterior",
-        "NEXT": "proxima user story",
-        "TITLE_DELETE_ACTION": "Apagar user story",
-        "LIGHTBOX_TITLE_BLOKING_US": "Bloqueando user story",
+        "BLOCKED": "Esta história de usuário está bloqueada",
+        "PREVIOUS": "história de usuário anterior",
+        "NEXT": "proxima história de usuário",
+        "TITLE_DELETE_ACTION": "Apagar história de usuário",
+        "LIGHTBOX_TITLE_BLOKING_US": "História de usuário bloqueadora",
         "TASK_COMPLETED": "{{totalClosedTasks}}/{{totalTasks}} tarefas completas",
-        "ASSIGN": "Atribuir User Story",
+        "ASSIGN": "Atribuir História de Usuário",
         "NOT_ESTIMATED": "Não estimado",
-        "TOTAL_US_POINTS": "Pontos totais de US",
+        "TOTAL_US_POINTS": "Total de pontos de histórias",
         "FIELDS": {
             "TEAM_REQUIREMENT": "Requisitos da Equipe",
             "CLIENT_REQUIREMENT": "Requisitos do Cliente",
@@ -1013,7 +1013,7 @@
         "TITLE": "Atividade",
         "REMOVED": "removido",
         "ADDED": "adicionado",
-        "US_POINTS": "pontos EU ({{name}})",
+        "US_POINTS": "pontos de história ({{name}})",
         "NEW_ATTACHMENT": "novo anexo",
         "DELETED_ATTACHMENT": "apagar anexo",
         "UPDATED_ATTACHMENT": "anexo atualizado {{filename}}",
@@ -1030,16 +1030,16 @@
             "NAME": "nome",
             "DESCRIPTION": "descrição",
             "CONTENT": "conteúdo",
-            "STATUS": "Situação",
+            "STATUS": "status",
             "IS_CLOSED": "está fechado",
             "FINISH_DATE": "Data de término",
             "TYPE": "Digite",
             "PRIORITY": "prioridade",
-            "SEVERITY": "Severidade",
+            "SEVERITY": "gravidade",
             "ASSIGNED_TO": "Assinado à",
             "WATCHERS": "Observadores",
             "MILESTONE": "sprint",
-            "USER_STORY": "user story",
+            "USER_STORY": "história de usuário",
             "PROJECT": "projeto",
             "IS_BLOCKED": "está bloqueada",
             "BLOCKED_NOTE": "Nota de bloqueio",
@@ -1055,41 +1055,41 @@
             "SPRINT_ORDER": "ordem de sprint ",
             "KANBAN_ORDER": "pedido kanban",
             "TASKBOARD_ORDER": "Ordem de quadro de tarefa",
-            "US_ORDER": "requisição US "
+            "US_ORDER": "ordem da história de usuário"
         }
     },
     "BACKLOG": {
         "PAGE_TITLE": "Backlog - {{projectName}}",
-        "PAGE_DESCRIPTION": "O painel de backlog, com user stories e sprints do projeto {{projectName}}: {{projectDescription}}",
+        "PAGE_DESCRIPTION": "O painel de backlog, com histórias de usuário e sprints do projeto {{projectName}}: {{projectDescription}}",
         "SECTION_NAME": "Backlog",
         "CUSTOMIZE_GRAPH": "Personalize seu gráficos de backlog",
-        "CUSTOMIZE_GRAPH_TEXT": "To have a nice graph that helps you follow the evolution of the project you have to set up the points and sprints through the",
+        "CUSTOMIZE_GRAPH_TEXT": "Para ter um gráfico que te ajuda a seguir a evolução do projeto você deve configurar os pontos e as sprints via",
         "CUSTOMIZE_GRAPH_ADMIN": "Administrador",
         "CUSTOMIZE_GRAPH_TITLE": "Configure os pontos e sprints pelo Administrador",
-        "MOVE_US_TO_CURRENT_SPRINT": "Mover para sprint corrente",
-        "MOVE_US_TO_LATEST_SPRINT": "ir para o último sprint",
+        "MOVE_US_TO_CURRENT_SPRINT": "Mover para a Sprint Atual",
+        "MOVE_US_TO_LATEST_SPRINT": "Mover para a última Sprint",
         "SHOW_FILTERS": "Mostrar filtros",
         "SHOW_TAGS": "Exibir tags",
         "EMPTY": "O backlog está vazio!",
-        "CREATE_NEW_US": "Criar uma nova EU",
-        "CREATE_NEW_US_EMPTY_HELP": "Você talvez queira criar uma nova user story",
+        "CREATE_NEW_US": "Criar uma nova História de Usuário",
+        "CREATE_NEW_US_EMPTY_HELP": "Você talvez queira criar uma nova história de usuário",
         "EXCESS_OF_POINTS": "Excesso de pontos",
         "PENDING_POINTS": "Pontos Pendentes",
         "CLOSED_POINTS": "fechado",
-        "COMPACT_SPRINT": "Sprint Resumido",
+        "COMPACT_SPRINT": "Sprint Resumida",
         "GO_TO_TASKBOARD": "Ir ao quadro de tarefas de {{::name}}",
         "EDIT_SPRINT": "Editar sprint",
         "TOTAL_POINTS": "total",
-        "STATUS_NAME": "Nome de Situação",
+        "STATUS_NAME": "Nome de Status",
         "SORTABLE_FILTER_ERROR": "Você não pode jogar sobre o  backlog quando filtros estão abertos",
         "DOOMLINE": "Escopo do projeto [Doomline]",
         "CHART": {
-            "XAXIS_LABEL": "Sprintes",
+            "XAXIS_LABEL": "Sprints",
             "YAXIS_LABEL": "Pontos",
-            "OPTIMAL": "Ideal de pontos pendentes para o sprint \"{{sprintName}}\" deve ser {{value}}",
-            "REAL": "Pontos realmente pendentes para o sprint \"{{sprintName}}\" é {{value}}",
-            "INCREMENT_TEAM": "Pontos incrementados pelos requisitos do time para o sprint  \"{{sprintName}}\" é {{value}}",
-            "INCREMENT_CLIENT": "Pontos incrementados pelos requisitos do cliente para o sprint \"{{sprintName}}\" é {{value}}"
+            "OPTIMAL": "Ideal de pontos pendentes para a sprint \"{{sprintName}}\" deve ser {{value}}",
+            "REAL": "Pontos realmente pendentes para a sprint \"{{sprintName}}\" é {{value}}",
+            "INCREMENT_TEAM": "Pontos acrescentados pelos requisitos do time para a sprint  \"{{sprintName}}\" é {{value}}",
+            "INCREMENT_CLIENT": "Pontos acrescentados pelos requisitos do cliente para a sprint \"{{sprintName}}\" é {{value}}"
         },
         "TAGS": {
             "TOGGLE": "Alternar visibilidade das tags",
@@ -1097,7 +1097,7 @@
             "HIDE": "Esconder tags"
         },
         "TABLE": {
-            "COLUMN_US": "User Stories",
+            "COLUMN_US": "Histórias de Usuários",
             "TITLE_COLUMN_POINTS": "Selecionar exibição por função"
         },
         "SPRINT_SUMMARY": {
@@ -1107,7 +1107,7 @@
             "CLOSED_TASKS": "tarefas<br />fechadas",
             "IOCAINE_DOSES": "iocaine<br />doses",
             "SHOW_STATISTICS_TITLE": "Mostrar estatísticas",
-            "TOGGLE_BAKLOG_GRAPH": "Mostrar/Esconder gráfico burndown"
+            "TOGGLE_BAKLOG_GRAPH": "Mostrar/Esconder gráfico de burndown"
         },
         "SUMMARY": {
             "PROJECT_POINTS": "pontos do<br />projeto",
@@ -1121,22 +1121,22 @@
             "REMOVE": "Remover filtros",
             "HIDE": "Esconder Filtros",
             "SHOW": "Mostrar Filtros",
-            "FILTER_CATEGORY_STATUS": "Situação",
+            "FILTER_CATEGORY_STATUS": "Status",
             "FILTER_CATEGORY_TAGS": "Tags"
         },
         "SPRINTS": {
             "TITLE": "SPRINTS",
             "DATE": "DD MMM YYYY",
-            "LINK_TASKBOARD": "Quadro de tarefas do sprint",
+            "LINK_TASKBOARD": "Quadro de tarefas da Sprint",
             "TITLE_LINK_TASKBOARD": "ir para quadro de tarefas de \"{{name}}\"",
             "NUMBER_SPRINTS": "<br/>sprints",
             "EMPTY": "Ainda não temos sprints.",
-            "WARNING_EMPTY_SPRINT_ANONYMOUS": "Esse sprint não tem estórias de usuário",
-            "WARNING_EMPTY_SPRINT": "Solte aqui estórias do seu backlog para iniciar uma nova sprint",
+            "WARNING_EMPTY_SPRINT_ANONYMOUS": "Esta sprint não tem Histórias de Usuário",
+            "WARNING_EMPTY_SPRINT": "Solte aqui Histórias do seu backlog para iniciar uma nova sprint",
             "TITLE_ACTION_NEW_SPRINT": "Adicionar nova sprint",
             "TEXT_ACTION_NEW_SPRINT": "Você poderá querer criar uma nova sprint em seu projeto",
-            "ACTION_SHOW_CLOSED_SPRINTS": "Mostre os sprints fechados",
-            "ACTION_HIDE_CLOSED_SPRINTS": "Esconder sprints fechados"
+            "ACTION_SHOW_CLOSED_SPRINTS": "Mostrar sprints fechadas",
+            "ACTION_HIDE_CLOSED_SPRINTS": "Esconder sprints fechadas"
         }
     },
     "ERROR": {
@@ -1148,7 +1148,7 @@
         "VERSION_ERROR": "Alguém dentro da Taiga mudou isso antes e nosso Oompa Loompa não podem aplicar suas alterações. Recarregue a página e aplique-as novamente (elas serão perdidas, agora)."
     },
     "TASKBOARD": {
-        "PAGE_TITLE": "{{sprintName}} - Quadro de Tarefas do Sprint - {{projectName}}",
+        "PAGE_TITLE": "{{sprintName}} - Quadro de Tarefas da Sprint - {{projectName}}",
         "PAGE_DESCRIPTION": "Sprint {{sprintName}} (de{{startDate}} até {{endDate}}) para {{projectName}}. Completos {{completedPercentage}}% ({{completedPoints}} de {{totalPoints}} pontos). {{openTasks}} tarefas abertas de  {{totalTasks}}.",
         "SECTION_NAME": "Quadro de Tarefas",
         "TITLE_ACTION_ADD": "Adicionar uma nova Tarefa",
@@ -1156,9 +1156,9 @@
         "TITLE_ACTION_ASSIGN": "Assinalar tarefa",
         "TITLE_ACTION_EDIT": "Editar tarefa",
         "PLACEHOLDER_CARD_TITLE": "Isto pode ser uma atividade",
-        "PLACEHOLDER_CARD_TEXT": "Separe Estórias em atividades  para rastrear separadamente.",
+        "PLACEHOLDER_CARD_TEXT": "Separe Histórias de Usuários em atividades para rastreá-las separadamente.",
         "TABLE": {
-            "COLUMN": "user story",
+            "COLUMN": "História de usuário",
             "TITLE_ACTION_FOLD": "Recolher coluna",
             "TITLE_ACTION_UNFOLD": "Abrir coluna",
             "TITLE_ACTION_FOLD_ROW": "Guardar Linha",
@@ -1181,11 +1181,11 @@
         "LINK_TASKBOARD": "Quadro de Tarefas",
         "TITLE_LINK_TASKBOARD": "Ir para o quadro de tarefas",
         "PLACEHOLDER_SUBJECT": "Digite um novo titulo para tarefa",
-        "TITLE_SELECT_STATUS": "Nome de Situação",
+        "TITLE_SELECT_STATUS": "Nome de Status",
         "OWNER_US": "Esta tarefa pertence a ",
-        "TITLE_LINK_GO_OWNER": "Ir para user story",
+        "TITLE_LINK_GO_OWNER": "Ir para história de usuário",
         "ORIGIN_US": "Essa tarefa foi criada a partir de",
-        "TITLE_LINK_GO_ORIGIN": "Ir para user story",
+        "TITLE_LINK_GO_ORIGIN": "Ir para história de usuário",
         "BLOCKED": "Esta tarefa está bloqueada",
         "PREVIOUS": "tarefa anterior",
         "NEXT": "nova tarefa",
@@ -1193,7 +1193,7 @@
         "LIGHTBOX_TITLE_BLOKING_TASK": "Tarefa bloqueadora",
         "FIELDS": {
             "MILESTONE": "Sprint",
-            "USER_STORY": "User story",
+            "USER_STORY": "História de usuário",
             "IS_IOCAINE": "É Iocaine"
         },
         "ACTION_IOCAINE": "Iocaine",
@@ -1216,7 +1216,7 @@
         "SUCCESS": "Nossos Oompa Loompas removeram sua conta"
     },
     "CHANGE_EMAIL_FORM": {
-        "TITLE": "Mudar seu email",
+        "TITLE": "Mudar seu e-mail",
         "SUBTITLE": "Só mais um clique e seu email será atualizado!",
         "PLACEHOLDER_INPUT_TOKEN": "mudar token do email",
         "ACTION_CHANGE_EMAIL": "Mudar email",
@@ -1226,26 +1226,26 @@
         "PAGE_TITLE": "Problemas - {{projectName}}",
         "PAGE_DESCRIPTION": "O painel de problemas do projeto {{projectName}}: {{projectDescription}}",
         "LIST_SECTION_NAME": "Problemas",
-        "SECTION_NAME": "Detalhes do caso",
-        "ACTION_NEW_ISSUE": "+ NOVO CASO",
-        "ACTION_PROMOTE_TO_US": "Promover para User Story",
+        "SECTION_NAME": "Detalhes do problema",
+        "ACTION_NEW_ISSUE": "+ NOVO PROBLEMA",
+        "ACTION_PROMOTE_TO_US": "Promover para História de Usuário",
         "PLACEHOLDER_FILTER_NAME": "Digite o nome do filtro e pressione Enter",
-        "PROMOTED": "Esse caso foi promovido para user strory",
-        "EXTERNAL_REFERENCE": "Esse caso foi criado a partir de",
+        "PROMOTED": "Esse problema foi promovido para história de usuário",
+        "EXTERNAL_REFERENCE": "Esse problema foi criado a partir de",
         "GO_TO_EXTERNAL_REFERENCE": "Ir para a origem",
-        "BLOCKED": "Esse caso está bloqueado",
-        "TITLE_PREVIOUS_ISSUE": "caso anterior",
-        "TITLE_NEXT_ISSUE": "próximo caso",
-        "ACTION_DELETE": "Caso apagado",
-        "LIGHTBOX_TITLE_BLOKING_ISSUE": "Caso que está bloqueando",
+        "BLOCKED": "Esse problema está bloqueado",
+        "TITLE_PREVIOUS_ISSUE": "problema anterior",
+        "TITLE_NEXT_ISSUE": "próximo problema",
+        "ACTION_DELETE": "Problema apagado",
+        "LIGHTBOX_TITLE_BLOKING_ISSUE": "Problema que está bloqueando",
         "FIELDS": {
             "PRIORITY": "Prioridade",
-            "SEVERITY": "Severidade",
+            "SEVERITY": "Gravidade",
             "TYPE": "Tipo"
         },
         "CONFIRM_PROMOTE": {
-            "TITLE": "Promover esse caso para nova user story",
-            "MESSAGE": "Você tem certeza que deseja criar uma nova HU para esse caso?"
+            "TITLE": "Promover esse problema para nova história de usuário",
+            "MESSAGE": "Você tem certeza que deseja criar uma nova História de Usuário a partir desse problema?"
         },
         "FILTERS": {
             "TITLE": "Filtros",
@@ -1256,8 +1256,8 @@
             "TITLE_BREADCRUMB": "Filtros",
             "CATEGORIES": {
                 "TYPE": "Tipo",
-                "STATUS": "Situação",
-                "SEVERITY": "Severidade",
+                "STATUS": "Status",
+                "SEVERITY": "Gravidade",
                 "PRIORITIES": "Prioridades",
                 "TAGS": "Tags",
                 "ASSIGNED_TO": "Atribuído a",
@@ -1272,11 +1272,11 @@
         "TABLE": {
             "COLUMNS": {
                 "TYPE": "Tipo",
-                "SEVERITY": "Severidade",
+                "SEVERITY": "Gravidade",
                 "PRIORITY": "Prioridade",
                 "SUBJECT": "Assunto",
                 "VOTES": "Votos",
-                "STATUS": "Situação",
+                "STATUS": "Status",
                 "CREATED": "Criado",
                 "ASSIGNED_TO": "Atribuído a"
             },
@@ -1284,38 +1284,38 @@
             "TITLE_ACTION_ASSIGNED_TO": "Atribuído a",
             "BLOCKED": "Bloqueado",
             "EMPTY": {
-                "TITLE": "Não há casos para reportar :-)",
-                "SUBTITLE": "Você encontrou um caso ?"
+                "TITLE": "Não há problemas para reportar :-)",
+                "SUBTITLE": "Você encontrou um problema?"
             }
         }
     },
     "ISSUE": {
         "PAGE_TITLE": "{{issueSubject}} - problema {{issueRef}} - {{projectName}}",
-        "PAGE_DESCRIPTION": "Estado: {{issueStatus }}. Tipo: {{issueType}}, Prioridade: {{issuePriority}}. severidade: {{issueSeverity}}. Descrição: {{issueDescription}}"
+        "PAGE_DESCRIPTION": "Estado: {{issueStatus }}. Tipo: {{issueType}}, Prioridade: {{issuePriority}}. gravidade: {{issueSeverity}}. Descrição: {{issueDescription}}"
     },
     "KANBAN": {
         "PAGE_TITLE": "Kanban - {{projectName}}",
-        "PAGE_DESCRIPTION": "O painel do kanban, contendo user stories do projeto {{projectName}}: {{projectDescription}}",
+        "PAGE_DESCRIPTION": "O painel do kanban, contendo histórias de usuários do projeto {{projectName}}: {{projectDescription}}",
         "SECTION_NAME": "Kanban",
         "TITLE_ACTION_FOLD": "Recolher coluna",
         "TITLE_ACTION_UNFOLD": "Abrir coluna",
         "TITLE_ACTION_FOLD_CARDS": "Guardar cartões",
         "TITLE_ACTION_UNFOLD_CARDS": "Mostrar cartões",
-        "TITLE_ACTION_ADD_US": "Adicionar Nova User Story",
+        "TITLE_ACTION_ADD_US": "Adicionar Nova História de Usuário",
         "TITLE_ACTION_ADD_BULK": "Adicionar novo lote",
         "ACTION_SHOW_ARCHIVED": "Mostrar arquivados",
         "ACTION_HIDE_ARCHIVED": "esconder arquivados",
-        "HIDDEN_USER_STORIES": "As user stories nesse status estão escondidas por padrão",
+        "HIDDEN_USER_STORIES": "As histórias de usuários nesse status são escondidas por padrão",
         "ARCHIVED": "Você arquivou",
         "UNDO_ARCHIVED": "Pegue e arraste novamente para desfazer",
-        "PLACEHOLDER_CARD_TITLE": "Estas são suas Estórias de Usuário ",
-        "PLACEHOLDER_CARD_TEXT": "Estórias deverá também ter sub-atividades para separar os requerimentos"
+        "PLACEHOLDER_CARD_TITLE": "Estas são suas Histórias de Usuários",
+        "PLACEHOLDER_CARD_TEXT": "Histórias poderão também ter sub-atividades para separar os requisitos"
     },
     "SEARCH": {
         "PAGE_TITLE": "Buscar - {{projectName}}",
-        "PAGE_DESCRIPTION": "Busque qualquer coisa, user stories, casos, tarefas, ou páginas da wiki, no projeto {{projectName}}: {{projectDescription}}",
-        "FILTER_USER_STORIES": "User Stories",
-        "FILTER_ISSUES": "casos",
+        "PAGE_DESCRIPTION": "Busque qualquer coisa, histórias de usuários, problemas, tarefas, ou páginas da wiki, no projeto {{projectName}}: {{projectDescription}}",
+        "FILTER_USER_STORIES": "Histórias de Usuários",
+        "FILTER_ISSUES": "Problemas",
         "FILTER_TASKS": "Tarefas",
         "FILTER_WIKI": "Paginas Wiki",
         "PLACEHOLDER_SEARCH": "Procurar em...",
@@ -1330,13 +1330,13 @@
         "APP_TITLE": "EQUIPE - {{projectName}}",
         "PLACEHOLDER_INPUT_SEARCH": "Procurar pelo nome completo...",
         "COLUMN_MR_WOLF": "Sr. Wolf",
-        "EXPLANATION_COLUMN_MR_WOLF": "Fechar caso",
+        "EXPLANATION_COLUMN_MR_WOLF": "Problemas fechados",
         "COLUMN_IOCAINE": "Bebedor de Iocaine",
         "EXPLANATION_COLUMN_IOCAINE": "Doses de Iocaine ingeridas",
         "COLUMN_CERVANTES": "Pero Vaz de Caminha",
         "EXPLANATION_COLUMN_CERVANTES": "Páginas wiki editadas",
         "COLUMN_BUG_HUNTER": "Caçador de bugs",
-        "EXPLANATION_COLUMN_BUG_HUNTER": "Caso reportado",
+        "EXPLANATION_COLUMN_BUG_HUNTER": "Problemas reportados",
         "COLUMN_NIGHT_SHIFT": "Periodo Noturno",
         "EXPLANATION_COLUMN_NIGHT_SHIFT": "Tarefa fechada",
         "COLUMN_TOTAL_POWER": "Total de poder",
@@ -1389,16 +1389,16 @@
             "LANGUAGE": "Idioma",
             "LANGUAGE_DEFAULT": "-- usar idioma padrão --",
             "THEME": "Tema",
-            "THEME_DEFAULT": "-- user tema padrão --"
+            "THEME_DEFAULT": "-- usar tema padrão --"
         }
     },
     "WIZARD": {
         "SECTION_TITLE_CREATE_PROJECT": "Criar Projeto",
         "CREATE_PROJECT_TEXT": "Novo em folha. Tão excitante!",
         "CHOOSE_TEMPLATE": "Which template fits your project best?",
-        "CHOOSE_TEMPLATE_TITLE": "More info about project templates",
-        "CHOOSE_TEMPLATE_INFO": "More info",
-        "PROJECT_DETAILS": "Project Details",
+        "CHOOSE_TEMPLATE_TITLE": "Mais informações sobre templates de projeto",
+        "CHOOSE_TEMPLATE_INFO": "Mais informações",
+        "PROJECT_DETAILS": "Detalhes do Projeto",
         "PUBLIC_PROJECT": "Projeto Público",
         "PRIVATE_PROJECT": "Projeto Privado",
         "CREATE_PROJECT": "Criar projeto",
@@ -1413,7 +1413,7 @@
         "PLACEHOLDER_PAGE": "Escreve sua página wiki",
         "REMOVE": "Remover essa página wiki",
         "DELETE_LIGHTBOX_TITLE": "Apagar página Wiki",
-        "DELETE_LINK_TITLE": "Delete Wiki link",
+        "DELETE_LINK_TITLE": "Remover link de Wiki",
         "NAVIGATION": {
             "SECTION_NAME": "Links",
             "ACTION_ADD_LINK": "Adicionar link"
@@ -1432,44 +1432,44 @@
         "HINT1_TEXT": "Isso permite você extrair todo o seu conteúdo de um Taiga e mover para outro.",
         "HINT2_TITLE": "Você sabia que pode criar campos personalizados?",
         "HINT2_TEXT": "Equipes agora podem personalizar campos, um jeito flexível de inserir dados específicos para uso em seu próprio fluxo de trabalho.",
-        "HINT3_TITLE": "Reorder your projects to feature those most relevant to you.",
+        "HINT3_TITLE": "Reordene seus projetos para evidenciar os mais relevantes para você.",
         "HINT3_TEXT": "The 10 projects are listed in the direct access bar at the top.",
         "HINT4_TITLE": "Você esqueceu onde está trabalhando?",
-        "HINT4_TEXT": "Não se preocupe, no seu painel você vai encontrar suas tarefas abertas, casos, e user stories na ordem que você trabalha neles."
+        "HINT4_TEXT": "Não se preocupe, no seu painel você vai encontrar suas tarefas abertas, problemas, e histórias de usuários na ordem em que você trabalhou nelas."
     },
     "TIMELINE": {
         "UPLOAD_ATTACHMENT": "{{username}} adicionou um novo anexo em {{obj_name}}",
-        "US_CREATED": "{{username}} criou uma nova US {{obj_name}} em {{project_name}}",
-        "ISSUE_CREATED": "{{username}} criou um novo caso {{obj_name}} em {{project_name}}",
+        "US_CREATED": "{{username}} criou uma nova História de Usuário {{obj_name}} em {{project_name}}",
+        "ISSUE_CREATED": "{{username}} criou um novo problema {{obj_name}} em {{project_name}}",
         "TASK_CREATED": "{{username}} criou uma nova tarefa {{obj_name}} em {{project_name}}",
-        "TASK_CREATED_WITH_US": "{{username}} criou nova tarefa {{obj_name}} em {{project_name}} que pertence a US {{us_name}}",
+        "TASK_CREATED_WITH_US": "{{username}} criou nova tarefa {{obj_name}} em {{project_name}} que pertence a História de Usuário {{us_name}}",
         "WIKI_CREATED": "{{username}} criou uma página wiki {{obj_name}} em {{project_name}}",
-        "MILESTONE_CREATED": "{{username}} criou um novo sprint {{obj_name}} em {{project_name}}",
+        "MILESTONE_CREATED": "{{username}} criou uma nova sprint {{obj_name}} em {{project_name}}",
         "NEW_PROJECT": "{{username}} criou o projeto {{project_name}}",
-        "MILESTONE_UPDATED": "{{username}} atualizou o sprint {{obj_name}}",
-        "US_UPDATED": "{{username}} atualizou o atributo \"{{field_name}}\" da US {{obj_name}}",
+        "MILESTONE_UPDATED": "{{username}} atualizou a sprint {{obj_name}}",
+        "US_UPDATED": "{{username}} atualizou o atributo \"{{field_name}}\" da História de Usuário {{obj_name}}",
         "US_UPDATED_WITH_NEW_VALUE": "{{username}} atualizou o trabalho \"{{field_name}}\" da US {{obj_name}} para {{new_value}}",
-        "US_UPDATED_POINTS": "{{username}} atualizou pontos de '{{role_name}}' da US {{obj_name}} para {{new_value}}",
-        "ISSUE_UPDATED": "{{username}} atualizou o atributo \"{{field_name}}\" do caso {{obj_name}}",
-        "ISSUE_UPDATED_WITH_NEW_VALUE": "{{username}} atualizou o atributo \"{{field_name}}\" do caso {{obj_name}} para {{new_value}}",
+        "US_UPDATED_POINTS": "{{username}} atualizou pontos de '{{role_name}}' da História de Usuário {{obj_name}} para {{new_value}}",
+        "ISSUE_UPDATED": "{{username}} atualizou o atributo \"{{field_name}}\" do problema {{obj_name}}",
+        "ISSUE_UPDATED_WITH_NEW_VALUE": "{{username}} atualizou o atributo \"{{field_name}}\" do problema  {{obj_name}} para {{new_value}}",
         "TASK_UPDATED": "{{username}} atualizou o atributo \"{{field_name}}\" da tarefa {{obj_name}} para {{new_value}}",
         "TASK_UPDATED_WITH_NEW_VALUE": "{{username}} Atualizou o atributo \"{{field_name}}\" da tarefa {{obj_name}} para {{new_value}}",
-        "TASK_UPDATED_WITH_US": "{{username}} atualizou o atributo \"{{field_name}}\" da tarefa{{obj_name}}  que pertence a US {{us_name}}",
-        "TASK_UPDATED_WITH_US_NEW_VALUE": "{{username}} atualizou o atributo \"{{field_name}}\" da tarefa {{obj_name}} que pertence a US {{us_name}} para {{new_value}}",
+        "TASK_UPDATED_WITH_US": "{{username}} atualizou o atributo \"{{field_name}}\" da tarefa {{obj_name}}  que pertence à História de Usuário {{us_name}}",
+        "TASK_UPDATED_WITH_US_NEW_VALUE": "{{username}} atualizou o atributo \"{{field_name}}\" da tarefa {{obj_name}} que pertence à História de Usuário {{us_name}} para {{new_value}}",
         "WIKI_UPDATED": "{{username}} atualizou a página wiki {{obj_name}}",
-        "NEW_COMMENT_US": "{{username}} comentou na  US {{obj_name}}",
-        "NEW_COMMENT_ISSUE": "{{username}} comentou no issue {{obj_name}}",
+        "NEW_COMMENT_US": "{{username}} comentou na História de Usuário {{obj_name}}",
+        "NEW_COMMENT_ISSUE": "{{username}} comentou no problema {{obj_name}}",
         "NEW_COMMENT_TASK": "{{username}} comentou na tarefa {{obj_name}}",
         "NEW_MEMBER": "{{project_name}} tem um membro novo",
-        "US_ADDED_MILESTONE": "{{username}} adicionou a estória {{obj_name}} a {{sprint_name}}",
-        "US_MOVED": "{{username}} moveu a US {{obj_name}}",
-        "US_REMOVED_FROM_MILESTONE": "{{username}} adicionou a US {{obj_name}} ao backlog",
+        "US_ADDED_MILESTONE": "{{username}} adicionou a História de Usuário {{obj_name}} a {{sprint_name}}",
+        "US_MOVED": "{{username}} moveu a História de Usuário {{obj_name}}",
+        "US_REMOVED_FROM_MILESTONE": "{{username}} adicionou a História de Usuário {{obj_name}} ao backlog",
         "BLOCKED": "{{username}} bloqueou {{obj_name}}",
         "UNBLOCKED": "{{username}} desbloqueou {{obj_name}}",
         "NEW_USER": "{{username}} ingressou no Taiga"
     },
     "LEGAL": {
-        "TERMS_OF_SERVICE_AND_PRIVACY_POLICY_AD": "<span>When creating a new account, you agree to our <br /></span><a href=\"{{ termsOfServiceUrl }}\" title=\"See terms of service\" target=\"_blank\">terms of service</a><span> and </span><a href=\"{{ privacyPolicyUrl }}\" title=\"See privacy policy\" target=\"_blank\">privacy policy</a>."
+        "TERMS_OF_SERVICE_AND_PRIVACY_POLICY_AD": "<span>Ao criar uma nova conta, você concorda com nossos <br /></span><a href=\"{{ termsOfServiceUrl }}\" title=\"Ver termos de serviço\" target=\"_blank\">termos de serviço</a><span> e </span><a href=\"{{ privacyPolicyUrl }}\" title=\"Ver política de privacidade\" target=\"_blank\">política de privacidade</a>."
     },
     "EXTERNAL_APP": {
         "PAGE_TITLE": "Um app externo requer autenticação",
@@ -1493,7 +1493,7 @@
             },
             "STEP2": {
                 "TITLE": "Trabalhando em",
-                "TEXT": "Aqui você irá encontrar as Estórias do Usuário, Atividades e Problemas no qual você está trabalhando."
+                "TEXT": "Aqui você irá encontrar as Histórias de Usuários, Atividades e Problemas em que você está trabalhando."
             },
             "STEP3": {
                 "TITLE": "Observando",
@@ -1514,15 +1514,15 @@
             },
             "STEP2": {
                 "TITLE": "Backlog do Produto",
-                "TEXT": "The backlog is the list of requirements (User Stories) for the project. Here is where you will plan your sprints."
+                "TEXT": "O backlog é a lista de requisitos (Histórias de Usuário) do projeto. Aqui é onde você planejará suas sprints."
             },
             "STEP3": {
                 "TITLE": "Sprints",
-                "TEXT": "Sprints são períodos curtos de tempo (geralmente 2 semanas) durante o qual trabalho especificado tem que ser completado e entregue."
+                "TEXT": "Sprints são períodos curtos de tempo (geralmente 2 semanas) durante as quais o trabalho especificado tem que ser concluído e entregue."
             },
             "STEP4": {
-                "TITLE": "User Stories",
-                "TEXT": "Estes são os requisitos em alto nível. Você pode adicioná-los ao backlog e arrastá-los ao sprint em que deve ser entregue. "
+                "TITLE": "Histórias de Usuários",
+                "TEXT": "Estes são os requisitos em alto nível. Você pode adicioná-los ao backlog e arrastá-los à sprint em que devem ser entregues. "
             }
         },
         "KANBAN": {
@@ -1531,21 +1531,21 @@
                 "TEXT": "Set up the columns you need to map your workflow statuses through the admin."
             },
             "STEP2": {
-                "TITLE": "Estórias do Usuário & Atividades",
-                "TEXT": "Estórias do Usuário são os requerimentos de alto nível. Você pode arrastar eles para diferentes colunas."
+                "TITLE": "Histórias de Usuários & Atividades",
+                "TEXT": "Histórias de Usuários são os requisitos de alto nível. Você pode arrastá-los para diferentes colunas."
             },
             "STEP3": {
-                "TITLE": "Adicionando User Stories",
-                "TEXT1": "Você poderá adicionar uma única Estória do Usuário (Ícone add US) ou um grupo delas (ícone de add em massa)",
+                "TITLE": "Adicionando Histórias de Usuários",
+                "TEXT1": "Você poderá adicionar uma única História do Usuário (Ícone add US) ou um grupo delas (ícone de add em massa)",
                 "TEXT2": "Boa Sorte!"
             }
         }
     },
     "DISCOVER": {
-        "PAGE_TITLE": "Discover projects - Taiga",
-        "PAGE_DESCRIPTION": "Searchable directory of Public Projects in Taiga. Explore backlogs, timelines, issues, and teams. Check out the most liked or most active projects. Filter by Kanban or Scrum.",
+        "PAGE_TITLE": "Descubra projetos - Taiga",
+        "PAGE_DESCRIPTION": "Diretório pesquisável de projetos públicos no Taiga. Explore backlogs, linhas do tempo, problemas e times. Encontre os projetos mais curtidos ou mais ativos. Filtre por Kanban ou Scrum.",
         "DISCOVER_TITLE": "Descobrir projetos",
-        "DISCOVER_SUBTITLE": "{projects, plural, um{One public project to discover} outro{# public projects to discover}}",
+        "DISCOVER_SUBTITLE": "{projects, plural, one{One public project to discover} other{# public projects to discover}}",
         "MOST_ACTIVE": "Mais ativo",
         "MOST_ACTIVE_EMPTY": "Não tem projetos ativos ainda",
         "MOST_LIKED": "Mais curtidas",
@@ -1567,7 +1567,7 @@
         },
         "SEARCH": {
             "PAGE_TITLE": "Procurar - Descobrir projetos - Taiga",
-            "PAGE_DESCRIPTION": "Searchable directory of Public Projects in Taiga. Explore backlogs, timelines, issues, and teams. Check out the most liked or most active projects. Filter by Kanban or Scrum.",
+            "PAGE_DESCRIPTION": "Diretório pesquisável de projetos públicos no Taiga. Explore backlogs, linhas do tempo, problemas e times. Encontre os projetos mais curtidos ou mais ativos. Filtre por Kanban ou Scrum.",
             "INPUT_PLACEHOLDER": "Digite algo...",
             "ACTION_TITLE": "Procurar",
             "RESULTS": "Resultado de pesquisa."

--- a/app/locales/taiga/locale-ru.json
+++ b/app/locales/taiga/locale-ru.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Кажется, это значение некорректно.",
             "TYPE_EMAIL": "Это значение должно быть корректным email-адресом.",

--- a/app/locales/taiga/locale-ru.json
+++ b/app/locales/taiga/locale-ru.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Ваш текст здесь...",
             "PREVIEW_BUTTON": "Предварительный просмотр",
             "EDIT_BUTTON": "Редактировать",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Помощь по синтаксису Markdown"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/locales/taiga/locale-sv.json
+++ b/app/locales/taiga/locale-sv.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Det här värdet är felaktigt. ",
             "TYPE_EMAIL": "Värdet måste vara en giltig e-postadress",

--- a/app/locales/taiga/locale-sv.json
+++ b/app/locales/taiga/locale-sv.json
@@ -173,7 +173,7 @@
             "UNWATCH": "Frånkoppla visning",
             "WATCHERS": "Observatörer",
             "BUTTON_TITLE": "Visa/Visa inte den här posten",
-            "COUNTER_TITLE": "{total, plural, en{one watcher} andra{# watchers}}"
+            "COUNTER_TITLE": "{total, plural, one{one watcher} other{# watchers}}"
         },
         "VOTE_BUTTON": {
             "UPVOTE": "Rösta för",
@@ -765,8 +765,8 @@
         "HELP": "Organisera dina projekt och sätt in de mest använda här. <br/> De första 10 toppprojekten vill visas i toppnavigeringens projektlista. ",
         "PRIVATE": "Privata projekt",
         "LOOKING_FOR_PEOPLE": "This project is looking for people",
-        "FANS_COUNTER_TITLE": "{total, plural, one{one fan} andra{# fans}}",
-        "WATCHERS_COUNTER_TITLE": "{total, plural, en{one watcher} andra{# watchers}}",
+        "FANS_COUNTER_TITLE": "{total, plural, one{one fan} other{# fans}}",
+        "WATCHERS_COUNTER_TITLE": "{total, plural, en{one watcher} other{# watchers}}",
         "MEMBERS_COUNTER_TITLE": "{total, plural, one{one member} other{# members}}",
         "BLOCKED_PROJECT": {
             "BLOCKED": "Blocked project",
@@ -866,13 +866,13 @@
             "LIKED": "Likte",
             "UNLIKE": "Ogillar",
             "BUTTON_TITLE": "Gilla eller ogilla projektet",
-            "COUNTER_TITLE": "{total, plural, one{one fan} andra{# fans}}"
+            "COUNTER_TITLE": "{total, plural, one{one fan} other{# fans}}"
         },
         "WATCH_BUTTON": {
             "BUTTON_TITLE": "Visa projektet och lägg till egenskaper för avisering",
             "WATCH": "Visa",
             "WATCHING": "Bevakar",
-            "COUNTER_TITLE": "{total, plural, en{one watcher} andra{# watchers}}",
+            "COUNTER_TITLE": "{total, plural, en{one watcher} other{# watchers}}",
             "OPTIONS": {
                 "NOTIFY_ALL": "Motta alla notifieringar",
                 "NOTIFY_ALL_TITLE": "Motta alla notifieringar för det här projektet",
@@ -1018,7 +1018,7 @@
         "DELETED_ATTACHMENT": "ta bort bifogad fil",
         "UPDATED_ATTACHMENT": "uppdaterad bilaga {{filename}}",
         "DELETED_CUSTOM_ATTRIBUTE": "raderad anpassad atribut",
-        "SIZE_CHANGE": "Gjorde {size, plural, one{one change} annan{# changes}}",
+        "SIZE_CHANGE": "Gjorde {size, plural, one{one change} other{# changes}}",
         "VALUES": {
             "YES": "ja",
             "NO": "nej",

--- a/app/locales/taiga/locale-sv.json
+++ b/app/locales/taiga/locale-sv.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Din text här",
             "PREVIEW_BUTTON": "Förhandsvisa",
             "EDIT_BUTTON": "Redigera",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Hjälp för markeringssyntax"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/locales/taiga/locale-tr.json
+++ b/app/locales/taiga/locale-tr.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Takım gereksinimi, müsteriyi ilgilendirmeyen, ama projede yer alması zorunlu olan bir gereksinimdir.",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "Bu değer geçersiz gözüküyor",
             "TYPE_EMAIL": "Bu değer geçerli bir e-posta adresi olmalı.",

--- a/app/locales/taiga/locale-tr.json
+++ b/app/locales/taiga/locale-tr.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "Yazınız buraya..",
             "PREVIEW_BUTTON": "Ön izleme",
             "EDIT_BUTTON": "Düzenle",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Markdown yazım kılavuzu"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/locales/taiga/locale-zh-hant.json
+++ b/app/locales/taiga/locale-zh-hant.json
@@ -43,6 +43,8 @@
         "TEAM_REQUIREMENT": "Team requirement is a requirement that must exist in the project but should have no cost for the client",
         "OWNER": "Project Owner",
         "CAPSLOCK_WARNING": "Be careful! You are using capital letters in an input field that is case sensitive.",
+        "CONFIRM_CLOSE_EDIT_MODE_TITLE": "Are you sure you want to close the edit mode?",
+        "CONFIRM_CLOSE_EDIT_MODE_MESSAGE": "Remember that if you close the edit mode without saving all the changes will be lost",
         "FORM_ERRORS": {
             "DEFAULT_MESSAGE": "該數值似乎為無效",
             "TYPE_EMAIL": "該電子郵件應為有效地址",

--- a/app/locales/taiga/locale-zh-hant.json
+++ b/app/locales/taiga/locale-zh-hant.json
@@ -225,6 +225,7 @@
             "CODE_BLOCK_SAMPLE_TEXT": "你的文字在此",
             "PREVIEW_BUTTON": "預視　",
             "EDIT_BUTTON": "編輯",
+            "ATTACH_FILE_HELP": "Attach files by dragging & dropping on the textarea above.",
             "MARKDOWN_HELP": "Markdown 語法協助"
         },
         "PERMISIONS_CATEGORIES": {

--- a/app/modules/home/home.service.coffee
+++ b/app/modules/home/home.service.coffee
@@ -46,53 +46,44 @@ class HomeService extends taiga.Service
 
             return duty
 
+        _getValidDutiesAndAttachProjectInfo = (duties, dutyType)->
+            # Exclude duties where I'm not member of the project
+            duties = duties.filter((duty) ->
+                return projectsById.get(String(duty.get('project'))))
+
+            duties = duties.map (duty) ->
+                return _attachProjectInfoToDuty(duty, dutyType)
+
+            return duties
+
         assignedTo = workInProgress.get("assignedTo")
 
         if assignedTo.get("userStories")
-            _duties = assignedTo.get("userStories").map (duty) ->
-                return _attachProjectInfoToDuty(duty, "userstories")
-
+            _duties = _getValidDutiesAndAttachProjectInfo(assignedTo.get("userStories"), "userstories")
             assignedTo = assignedTo.set("userStories", _duties)
 
         if assignedTo.get("tasks")
-            _duties = assignedTo.get("tasks").map (duty) ->
-                return _attachProjectInfoToDuty(duty, "tasks")
-
+            _duties = _getValidDutiesAndAttachProjectInfo(assignedTo.get("tasks"), "tasks")
             assignedTo = assignedTo.set("tasks", _duties)
 
-        if assignedTo.get("issues")
-            _duties = assignedTo.get("issues").map (duty) ->
-                return _attachProjectInfoToDuty(duty, "issues")
 
+        if assignedTo.get("issues")
+            _duties = _getValidDutiesAndAttachProjectInfo(assignedTo.get("issues"), "issues")
             assignedTo = assignedTo.set("issues", _duties)
+
 
         watching = workInProgress.get("watching")
 
         if watching.get("userStories")
-            _duties = watching.get("userStories").filter (duty) ->
-                return !!projectsById.get(String(duty.get('project')))
-
-            _duties = _duties.map (duty) ->
-                return _attachProjectInfoToDuty(duty, "userstories")
-
+            _duties = _getValidDutiesAndAttachProjectInfo(watching.get("userStories"), "userstories")
             watching = watching.set("userStories", _duties)
 
         if watching.get("tasks")
-            _duties = watching.get("tasks").filter (duty) ->
-                return !!projectsById.get(String(duty.get('project')))
-
-            _duties = _duties.map (duty) ->
-                return _attachProjectInfoToDuty(duty, "tasks")
-
+            _duties = _getValidDutiesAndAttachProjectInfo(watching.get("tasks"), "tasks")
             watching = watching.set("tasks", _duties)
 
         if watching.get("issues")
-            _duties = watching.get("issues").filter (duty) ->
-                return !!projectsById.get(String(duty.get('project')))
-
-            _duties = _duties.map (duty) ->
-                return _attachProjectInfoToDuty(duty, "issues")
-
+            _duties = _getValidDutiesAndAttachProjectInfo(watching.get("issues"), "issues")
             watching = watching.set("issues", _duties)
 
         workInProgress = workInProgress.set("assignedTo", assignedTo)

--- a/app/partials/includes/components/summary.jade
+++ b/app/partials/includes/components/summary.jade
@@ -7,6 +7,9 @@ div.summary
     div.summary-stats(ng-if="stats.total_points")
         span.number(ng-bind="stats.total_points | number") --
         span.description(translate="BACKLOG.SUMMARY.PROJECT_POINTS")
+    div.summary-stats(ng-if="stats.tag_points")
+        span.number(ng-bind="stats.tag_points | number") --
+        span.description(translate="BACKLOG.SUMMARY.TAGS_POINTS")
     div.summary-stats
         span.number(ng-bind="stats.defined_points | number") --
         span.description(translate="BACKLOG.SUMMARY.DEFINED_POINTS")

--- a/app/partials/includes/modules/backlog-table.jade
+++ b/app/partials/includes/modules/backlog-table.jade
@@ -12,7 +12,7 @@ div.backlog-table-body(
     tg-backlog-sortable,
     ng-class="{'show-tags': ctrl.showTags, 'active-filters': ctrl.activeFilters}"
     infinite-scroll="ctrl.loadUserstories()"
-    infinite-scroll-disabled="ctrl.disablePagination"
+    infinite-scroll-disabled="ctrl.disablePagination || !ctrl.firstLoadComplete"
     infinite-scroll-immediate-check='false'
 )
     include ../components/backlog-row

--- a/app/partials/team/team-members.jade
+++ b/app/partials/team/team-members.jade
@@ -7,9 +7,13 @@
                 a.name(
                     tg-nav="user-profile:username=user.username",
                     title="{{::user.full_name_display}}"
-                ) {{::user.full_name_display}}
-                    svg.icon.icon-badge(ng-if="user.id == owner")
-                        tg-svg(svg-icon="icon-badge", svg-title-translate="COMMON.OWNER")
+                )
+                    {{::user.full_name_display}}
+                    tg-svg(
+                        ng-if="user.id == owner"
+                        svg-icon="icon-badge"
+                        svg-title-translate="COMMON.OWNER"
+                    )
 
                 span.position {{::user.role_name}}
 

--- a/app/partials/team/team-members.jade
+++ b/app/partials/team/team-members.jade
@@ -7,8 +7,7 @@
                 a.name(
                     tg-nav="user-profile:username=user.username",
                     title="{{::user.full_name_display}}"
-                )
-                    {{::user.full_name_display}}
+                ) {{::user.full_name_display}}
                     tg-svg(
                         ng-if="user.id == owner"
                         svg-icon="icon-badge"

--- a/app/styles/components/editor-help.scss
+++ b/app/styles/components/editor-help.scss
@@ -10,7 +10,7 @@
 }
 
 .drag-drop-help {
-    @include font-size(x-small);
+    @include font-size(xsmall);
     color: $gray;
 }
 

--- a/app/styles/components/filter.scss
+++ b/app/styles/components/filter.scss
@@ -1,5 +1,4 @@
 .single-filter {
-    @include font-size(large);
     @include font-type(text);
     @include clearfix;
     align-items: center;

--- a/app/styles/components/wysiwyg.scss
+++ b/app/styles/components/wysiwyg.scss
@@ -63,7 +63,7 @@
         margin-bottom: 1rem;
         overflow: auto;
         unicode-bidi: embed;
-        white-space: pre;
+        white-space: pre-wrap;
     }
     pre {
         line-height: 1.4rem;

--- a/app/styles/core/elements.scss
+++ b/app/styles/core/elements.scss
@@ -91,6 +91,9 @@ svg {
 
 // scss-lint:disable QualifyingElement
 div.awesomplete {
+    input {
+        display: inline-block;
+    }
     > ul {
         background: rgba($black, .95);
         color: $primary-light;

--- a/app/styles/layout/ticket-detail.scss
+++ b/app/styles/layout/ticket-detail.scss
@@ -193,6 +193,7 @@
         flex-basis: 250px;
         flex-shrink: 0;
         @include breakpoint(laptop) {
+            flex-basis: auto;
             order: 1;
         }
     }

--- a/app/styles/layout/ticket-detail.scss
+++ b/app/styles/layout/ticket-detail.scss
@@ -182,6 +182,7 @@
 }
 
 .subheader {
+    align-items: flex-start;
     display: flex;
     justify-content: space-between;
     @include breakpoint(laptop) {
@@ -192,14 +193,12 @@
         flex-basis: 250px;
         flex-shrink: 0;
         @include breakpoint(laptop) {
-            flex: 0;
             order: 1;
         }
     }
     .tags-block {
         flex: 1;
         @include breakpoint(laptop) {
-            flex: 0;
             order: 2;
         }
     }


### PR DESCRIPTION
When you're using tags in order to separate a project in subprojects, you often need to know how many points there is with a particular tag. That what this pull request does. If you select at least one tag, it will calculate the number of point by tag and display it on the summary. If not, it will disappear.

I just saw that someone changed the name of the function loadUserstories to loadAllPaginatedUserstories. Does it means the data send by the server is also paginated?