### PR TITLE
Remove comment in activity tab

### DIFF
--- a/app/modules/history/history/history.jade
+++ b/app/modules/history/history/history.jade
@@ -9,7 +9,6 @@ section.activities
                 .activity-data
                     span.activity-creator {{activity.user.name}}
                     span.activity-date {{activity.created_at | momentFormat:'DD MMM YYYY HH:mm'}}
-                p.activity-text(ng-if="activity.comment") {{activity.comment}}
 
                 .activity-diff(
                     ng-repeat="(key, diff) in activity.values_diff"


### PR DESCRIPTION
Currently is broke because we render markdown as plain text, but if we render markdown there are some cases when the information is duplicate (with github updates). So commnet tab show comments, and activity tab show activities (changes).

