### PR TITLE
Fix infinite-scroll dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -69,7 +69,7 @@
     "angular-translate-loader-partial": "~2.10.0",
     "angular-translate-loader-static-files": "~2.10.0",
     "angular-translate-interpolation-messageformat": "~2.10.0",
-    "ngInfiniteScroll": "^1.3.0",
+    "ngInfiniteScroll": "^1.3.1",
     "immutable": "~3.8.1",
     "bluebird": "~3.3.5",
     "intro.js": "~2.1.0",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -176,7 +176,7 @@ paths.libs = [
     paths.vendor + "raven-js/dist/raven.js",
     paths.vendor + "l.js/l.js",
     paths.vendor + "messageformat/locale/*.js",
-    paths.vendor + "ngInfiniteScroll/build/ng-infinite-scroll.js",
+    paths.vendor + "ngInfiniteScroll/dist/ng-infinite-scroll.js",
     paths.vendor + "immutable/dist/immutable.js",
     paths.vendor + "intro.js/intro.js",
     paths.vendor + "dragula.js/dist/dragula.js",


### PR DESCRIPTION
When trying to build taiga-front from scratch, bower will install ngInfiniteScroll 1.3.1, which has its dist in a different location than version 1.3.0. After running gulp, the resulting libs.js will thus not have the infinite-scroll library and the app will not load.

This PR fixes that by explicitly updating ngInfiniteScroll to at least 1.3.1 **and** updating the lib path to use the new location.