### PR TITLE
Actually fix infinite-scroll dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -69,7 +69,7 @@
     "angular-translate-loader-partial": "~2.10.0",
     "angular-translate-loader-static-files": "~2.10.0",
     "angular-translate-interpolation-messageformat": "~2.10.0",
-    "ngInfiniteScroll": "^1.3.1",
+    "ng-infinite-scroll-npm-is-better-than-bower": "^1.3.0",
     "immutable": "~3.8.1",
     "bluebird": "~3.3.5",
     "intro.js": "~2.1.0",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -176,7 +176,7 @@ paths.libs = [
     paths.vendor + "raven-js/dist/raven.js",
     paths.vendor + "l.js/l.js",
     paths.vendor + "messageformat/locale/*.js",
-    paths.vendor + "ngInfiniteScroll/dist/ng-infinite-scroll.js",
+    paths.vendor + "ng-infinite-scroll-npm-is-better-than-bower/build/ng-infinite-scroll.js",
     paths.vendor + "immutable/dist/immutable.js",
     paths.vendor + "intro.js/intro.js",
     paths.vendor + "dragula.js/dist/dragula.js",


### PR DESCRIPTION
The "fix" I introduced in PR #1133 was completely wrong: ngInfiniteScroll v1.3.1 does not ship with a "dist" directory (or even a "build" directory).
The official bower builds for ngInfiniteScroll can actually be found as "ng-infinite-scroll-npm-is-better-than-bower" (https://github.com/sroze/ngInfiniteScroll#bower).