### PR TITLE
Add custom project key feature to Git integrations

### DIFF
--- a/app/coffee/modules/admin/third-parties.coffee
+++ b/app/coffee/modules/admin/third-parties.coffee
@@ -571,6 +571,43 @@ module.directive("tgBitbucketWebhooks", ["$tgRepo", "$tgConfirm", "$tgLoading", 
 
 
 #############################################################################
+## GOGS Directive
+#############################################################################
+
+GogsWebhooksDirective = ($repo, $confirm, $loading) ->
+    link = ($scope, $el, $attrs) ->
+        form = $el.find("form").checksley({"onlyOneErrorElement": true})
+        submit = debounce 2000, (event) =>
+            event.preventDefault()
+
+            return if not form.validate()
+
+            currentLoading = $loading()
+                .target(submitButton)
+                .start()
+
+            promise = $repo.saveAttribute($scope.gogs, "gogs")
+            promise.then ->
+                currentLoading.finish()
+                $confirm.notify("success")
+                $scope.$emit("project:modules:reload")
+
+            promise.then null, (data) ->
+                currentLoading.finish()
+                form.setErrors(data)
+                if data._error_message
+                    $confirm.notify("error", data._error_message)
+
+        submitButton = $el.find(".submit-button")
+
+        $el.on "submit", "form", submit
+
+    return {link:link}
+
+module.directive("tgGogsWebhooks", ["$tgRepo", "$tgConfirm", "$tgLoading", GogsWebhooksDirective])
+
+
+#############################################################################
 ## Valid Origin IP's Directive
 #############################################################################
 ValidOriginIpsDirective = ->

--- a/app/locales/taiga/locale-ca.json
+++ b/app/locales/taiga/locale-ca.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Clau secreta",
             "PAYLOAD_URL": "Payload URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "IPs amb orige vàlid separades per ,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-de.json
+++ b/app/locales/taiga/locale-de.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Geheimschlüssel",
             "PAYLOAD_URL": "Payload URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Gültige Quell-IPs (getrennt von ,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -611,7 +611,8 @@
             "REPLACEMENT_ROLE": "All the users with this role will be moved to",
             "WARNING_DELETE_ROLE": "Be careful! All role estimations will be removed",
             "ERROR_DELETE_ALL": "You can't delete all values",
-            "EXTERNAL_USER": "External user"
+            "EXTERNAL_USER": "External user",
+            "NOTE_EXTERNAL_USERS": "<strong>Note:</strong> by External User we mean any anonymous user not belonging to the Taiga platform, including search engines. Please use this role with care."
         },
         "THIRD_PARTIES": {
             "SECRET_KEY": "Secret key",

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -617,6 +617,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Secret key",
             "PAYLOAD_URL": "Payload URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Valid origin IPs (separated by ,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-es.json
+++ b/app/locales/taiga/locale-es.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Secret key",
             "PAYLOAD_URL": "Payload URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "IPs de origen válidas (separadas por ,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-fi.json
+++ b/app/locales/taiga/locale-fi.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Salainen avain",
             "PAYLOAD_URL": "Yhteyden URL-osoite",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Vaadittavat lähdeIPt (pilkuilla eroteltuna)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-fr.json
+++ b/app/locales/taiga/locale-fr.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Clé secrète",
             "PAYLOAD_URL": "URL de Payload",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "IP sources valides (séparées par des virgules)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-it.json
+++ b/app/locales/taiga/locale-it.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Chiave segreta",
             "PAYLOAD_URL": "Payload URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Origina valida per l'IP (separato da ,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-ja.json
+++ b/app/locales/taiga/locale-ja.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "シークレットキー",
             "PAYLOAD_URL": "Payload URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Valid origin IPs (separated by ,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-ko.json
+++ b/app/locales/taiga/locale-ko.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "비밀 키",
             "PAYLOAD_URL": "Payload URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "유효한 원본 IP (콤마','로 구분)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-nb.json
+++ b/app/locales/taiga/locale-nb.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Hemmelig nøkkel",
             "PAYLOAD_URL": "Nyttelast URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Gyldige opprinnelses IP-adresser (atskilt med,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-nl.json
+++ b/app/locales/taiga/locale-nl.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Geheime sleutel",
             "PAYLOAD_URL": "Payload URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Correct origine IPs (gescheiden door ,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-pl.json
+++ b/app/locales/taiga/locale-pl.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Tajny klucz",
             "PAYLOAD_URL": "Payload URL",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Adresy IP(oddzielone przecinkami)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-pt-br.json
+++ b/app/locales/taiga/locale-pt-br.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Chave secreta",
             "PAYLOAD_URL": "URL da Payload",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "IPs de origem válidos (separados por vírgulas)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-ru.json
+++ b/app/locales/taiga/locale-ru.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Секретный ключ",
             "PAYLOAD_URL": "Ссылка на полезную нагрузку",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Правильные IP-адреса (через ,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-sv.json
+++ b/app/locales/taiga/locale-sv.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Hemlig nyckel",
             "PAYLOAD_URL": "Länk för paketinnhåll",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Giltig ursprunglig IP-adresser (separerat med ,)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-tr.json
+++ b/app/locales/taiga/locale-tr.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Gizli anahtar",
             "PAYLOAD_URL": "Paket URL'si",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "Geçerli çıkış IP'leri (virgülle ayrılmış olarak)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-zh-hans.json
+++ b/app/locales/taiga/locale-zh-hans.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "密钥",
             "PAYLOAD_URL": "有效负荷网址",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "有效来源IP(请用逗点分开)"
         },
         "BITBUCKET": {

--- a/app/locales/taiga/locale-zh-hant.json
+++ b/app/locales/taiga/locale-zh-hant.json
@@ -615,6 +615,7 @@
         "THIRD_PARTIES": {
             "SECRET_KEY": "Secret key",
             "PAYLOAD_URL": "有效載荷網址",
+            "PROJECT_KEY": "Project key",
             "VALID_IPS": "有效來源IP(請用逗點分開)"
         },
         "BITBUCKET": {

--- a/app/modules/services/avatar.service.coffee
+++ b/app/modules/services/avatar.service.coffee
@@ -86,7 +86,7 @@ class AvatarService
             logoUrl = encodeURIComponent(root + logo.src)
 
             return {
-                url: 'https://www.gravatar.com/avatar/' + gravatar + "?d=" + logoUrl,
+                url: 'https://www.gravatar.com/avatar/' + gravatar + "?s=200&d=" + logoUrl,
                 bg: logo.color
             }
 

--- a/app/partials/admin/admin-roles.jade
+++ b/app/partials/admin/admin-roles.jade
@@ -34,6 +34,9 @@ div.wrapper.roles(ng-controller="RolesController as ctrl",
 
         div.any-computable-role(ng-hide="anyComputableRole", translate="ADMIN.ROLES.WARNING_NO_ROLE")
 
+        div.general-category.external-user(ng-if="role.external_user")
+            span(translate="ADMIN.ROLES.NOTE_EXTERNAL_USERS")
+
         div.general-category(ng-if="!role.external_user")
             span(translate="ADMIN.ROLES.HELP_ROLE_ENABLED")
             div.check

--- a/app/partials/admin/admin-third-parties-bitbucket.jade
+++ b/app/partials/admin/admin-third-parties-bitbucket.jade
@@ -17,6 +17,17 @@ div.wrapper.roles(
 
         form
             fieldset
+                label(for="project-key", translate="ADMIN.THIRD_PARTIES.PROJECT_KEY")
+                input(
+                    id="project-key"
+                    type="text"
+                    name="project-key"
+                    ng-model="bitbucket.project_key"
+                    placeholder="{{'ADMIN.THIRD_PARTIES.PROJECT_KEY' | translate}}"
+                    data-regexp="[A-Z]{2,6}"
+                )
+
+            fieldset
                 label(for="secret-key", translate="ADMIN.THIRD_PARTIES.SECRET_KEY")
                 input(
                     id="secret-key"

--- a/app/partials/admin/admin-third-parties-github.jade
+++ b/app/partials/admin/admin-third-parties-github.jade
@@ -16,6 +16,17 @@ div.wrapper.roles(
 
         form
             fieldset
+                label(for="project-key", translate="ADMIN.THIRD_PARTIES.PROJECT_KEY")
+                input(
+                    id="project-key"
+                    type="text"
+                    name="project-key"
+                    ng-model="github.project_key"
+                    placeholder="{{'ADMIN.THIRD_PARTIES.PROJECT_KEY' | translate}}"
+                    data-regexp="[A-Z]{2,6}"
+                )
+
+            fieldset
                 label(for="secret-key", translate="ADMIN.THIRD_PARTIES.SECRET_KEY")
                 input(
                     id="secret-key"

--- a/app/partials/admin/admin-third-parties-gitlab.jade
+++ b/app/partials/admin/admin-third-parties-gitlab.jade
@@ -16,6 +16,17 @@ div.wrapper.roles(
 
         form
             fieldset
+                label(for="project-key", translate="ADMIN.THIRD_PARTIES.PROJECT_KEY")
+                input(
+                    id="project-key"
+                    type="text"
+                    name="project-key"
+                    ng-model="gitlab.project_key"
+                    placeholder="{{'ADMIN.THIRD_PARTIES.PROJECT_KEY' | translate}}"
+                    data-regexp="[A-Z]{2,6}"
+                )
+
+            fieldset
                 label(for="secret-key", translate="ADMIN.THIRD_PARTIES.SECRET_KEY")
                 input(
                     id="secret-key"

--- a/app/partials/admin/admin-third-parties-gogs.jade
+++ b/app/partials/admin/admin-third-parties-gogs.jade
@@ -16,6 +16,17 @@ div.wrapper.roles(
 
         form
             fieldset
+                label(for="project-key", translate="ADMIN.THIRD_PARTIES.PROJECT_KEY")
+                input(
+                    id="project-key"
+                    type="text"
+                    name="project-key"
+                    ng-model="gogs.project_key"
+                    placeholder="{{'ADMIN.THIRD_PARTIES.PROJECT_KEY' | translate}}"
+                    data-regexp="[A-Z]{2,6}"
+                )
+
+            fieldset
                 label(for="secret-key", translate="ADMIN.THIRD_PARTIES.SECRET_KEY")
                 input(
                     id="secret-key"

--- a/app/partials/issue/issues-detail.jade
+++ b/app/partials/issue/issues-detail.jade
@@ -61,6 +61,7 @@ div.wrapper(
             type="issue"
             name="issue"
             id="issue.id"
+            project-id="projectId"
         )
 
     sidebar.menu-secondary.sidebar.ticket-data

--- a/app/partials/task/task-detail.jade
+++ b/app/partials/task/task-detail.jade
@@ -70,6 +70,7 @@ div.wrapper(
             type="task"
             name="task"
             id="task.id"
+            project-id="projectId"
         )
 
     sidebar.menu-secondary.sidebar.ticket-data

--- a/app/styles/modules/admin/admin-roles.scss
+++ b/app/styles/modules/admin/admin-roles.scss
@@ -48,6 +48,9 @@
         display: flex;
         justify-content: flex-end;
         padding-bottom: 2rem;
+        &.external-user {
+            justify-content: flex-start;
+        }
         .check {
             margin-left: .5rem;
             input {


### PR DESCRIPTION
This pull request is for the enhancement/issue raised in taiga-back. [#980](https://github.com/taigaio/taiga-back/issues/980)

It adds the ability to define and use custom project keys to match Git commit messages in the hook. The default project_key is set to 'TG'.

I have set the project key validation to a minimum length of 2 and maximum length of 6 and only [A-Z] characters are accepted but that can be changed.

<img width="788" alt="screen shot 2017-05-01 at 2 00 04 am" src="https://cloud.githubusercontent.com/assets/8002179/25565917/cd5f1ce6-2e13-11e7-9f95-52654b1fce26.png">

