### PR TITLE
use javascript dates to allow render flot points on the right place

### DIFF
--- a/app/coffee/modules/taskboard/charts.coffee
+++ b/app/coffee/modules/taskboard/charts.coffee
@@ -42,7 +42,7 @@ SprintGraphDirective = ($translate)->
         width = element.width()
         element.height(240)
 
-        days = _.map(dataToDraw, (x) -> moment(x.day))
+        days = _.map(dataToDraw, (x) -> moment(new Date(x.day).getTime()))
 
         data = []
         data.unshift({


### PR DESCRIPTION
Pending points (optimal and real) were not aligned with time axis. Reading the documentation I found that the problem can be solved because days must be in UTC.
So, formatting dates (e.g. `'2017-03-24'`) with `new Date` javascript function is enough.

### Before

![graph-with-moved-dots-crop](https://cloud.githubusercontent.com/assets/761794/25849746/f2a8b6f8-34bf-11e7-9a56-104029de1a53.png)

### After

![graph-with-dots-crop](https://cloud.githubusercontent.com/assets/761794/25849745/f29f4ff0-34bf-11e7-904e-a959f8a763b2.png)
