### PR TITLE
Improved error logging if a plugin fails to load.

### DIFF
--- a/app-loader/app-loader.coffee
+++ b/app-loader/app-loader.coffee
@@ -46,8 +46,8 @@ loadPlugin = (pluginPath) ->
             else
                 resolve()
 
-        fail = () ->
-            console.error("error loading", pluginPath);
+        fail = (a, errorStr, e) ->
+            console.error("error loading", pluginPath, e);
 
         $.getJSON(pluginPath).then(success, fail)
 


### PR DESCRIPTION
Currently it's difficult to debug why a plugin failed to load. All this PR does is logs the exception to console.error, making it much easier to trace bad plugins.