### PR TITLE
Fixed property typo in the Related US Controller

### DIFF
--- a/app/modules/epics/related-userstories/related-userstories-controller.coffee
+++ b/app/modules/epics/related-userstories/related-userstories-controller.coffee
@@ -30,7 +30,7 @@ class RelatedUserStoriesController
         @.showCreateRelatedUserstoriesLightbox = false
 
     showRelatedUserStoriesSection: () ->
-        return @projectService.hasPermission("view_epics") or @.userstories?.legth > 0
+        return @projectService.hasPermission("view_epics") or @.userstories?.length > 0
 
     userCanSort: () ->
         return @projectService.hasPermission("modify_epic")


### PR DESCRIPTION
A reference to the `.length` property of `@.userstories` was originally misspelled.