### PR TITLE
remove unnecessary meta tag

### DIFF
--- a/app/index.jade
+++ b/app/index.jade
@@ -9,7 +9,6 @@ html(lang="en")
         title Taiga
         meta(name="description", content="Taiga is a project management platform for startups and agile developers & designers who want a simple, beautiful tool that makes work truly enjoyable.")
         meta(name="keywords", content="agile, scrum, taiga, management, project, developer, designer, user experience")
-        meta(http-equiv="X-Frame-Options", content="deny")
 
         //-meta(name="viewport", content="width=device-width, user-scalable=no")
         link(rel="stylesheet", href="/#{v}/styles/theme-taiga.css")


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) setting the meta tag is useless. For instance, `<meta http-equiv="X-Frame-Options" content="deny">` has no effect. So I have removed this line `meta(http-equiv="X-Frame-Options", content="deny")`.
This PR fixes #1283 