### PR TITLE
User story data filter by milestone

### DIFF
--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -365,7 +365,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         @.initializeSubscription()
 
         return @.loadBacklog()
-            .then(=> @.generateFilters())
+            .then(=> @.generateFilters(milestone = "null"))
             .then(=> @scope.$emit("backlog:loaded"))
 
     prepareBulkUpdateData: (uses, field="backlog_order") ->

--- a/app/coffee/modules/controllerMixins.coffee
+++ b/app/coffee/modules/controllerMixins.coffee
@@ -207,7 +207,7 @@ class UsFiltersMixin
             @filterRemoteStorageService.storeFilters(@scope.projectId, userFilters, @.storeCustomFiltersName).then(@.generateFilters)
             @.generateFilters()
 
-    generateFilters: ->
+    generateFilters: (milestone) ->
         @.storeFilters(@params.pslug, @location.search(), @.storeFiltersName)
 
         urlfilters = @location.search()
@@ -220,6 +220,9 @@ class UsFiltersMixin
         loadFilters.owner = urlfilters.owner
         loadFilters.epic = urlfilters.epic
         loadFilters.q = urlfilters.q
+
+        if milestone
+            loadFilters.milestone = milestone
 
         return @q.all([
             @rs.userstories.filtersData(loadFilters),


### PR DESCRIPTION
Fix a bug in the backlog page. Currently the user stories counts inside the filters tags count all user stories not only the user stories without sprint. 

This fix makes that the filters results would be the same as the expected number in filter count tags.

