### PR TITLE
Fix US ordering

### DIFF
--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -477,6 +477,10 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         for it, key in afterDestination # increase position of the us after the dragged us's
             orderList[it.id] = startIndex + key + 1
 
+        setNextOrders = _.map(afterDestination, (it) =>
+            {us_id: it.id, order: orderList[it.id]}
+        )
+
         # refresh order
         @scope.userstories = _.sortBy @scope.userstories, (it) => @.backlogOrder[it.id]
         @scope.visibleUserStories = _.map @scope.userstories, (it) -> return it.ref
@@ -489,14 +493,16 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
         # saving
         if usList.length > 1 && (newSprintId != oldSprintId) # drag multiple to sprint
-            data = modifiedUs.concat(setPreviousOrders)
+            data = modifiedUs.concat(setPreviousOrders, setNextOrders)
             promise = @rs.userstories.bulkUpdateMilestone(project, newSprintId, data)
         else if usList.length > 1 # drag multiple in backlog
-            data = modifiedUs.concat(setPreviousOrders)
+            data = modifiedUs.concat(setPreviousOrders, setNextOrders)
             promise = @rs.userstories.bulkUpdateBacklogOrder(project, data)
         else  # drag single
             setOrders = {}
             for it in setPreviousOrders
+                setOrders[it.us_id] = it.order
+            for it in setNextOrders
                 setOrders[it.us_id] = it.order
 
             options = {

--- a/app/coffee/modules/kanban/kanban-usertories.coffee
+++ b/app/coffee/modules/kanban/kanban-usertories.coffee
@@ -132,6 +132,15 @@ class KanbanUserstoriesService extends taiga.Service
 
         else if !previous
             startIndex = 0
+
+            for it, key in afterDestination # increase position of the us after the dragged us's
+                @.order[it.id] = key + initialLength + 1
+                it.kanban_order = @.order[it.id]
+
+            setNextOrders = _.map(afterDestination, (it) =>
+                {us_id: it.id, order: @.order[it.id]}
+            )
+
         else if previous
             startIndex = @.order[previous.id] + 1
 

--- a/app/coffee/modules/kanban/kanban-usertories.coffee
+++ b/app/coffee/modules/kanban/kanban-usertories.coffee
@@ -94,6 +94,7 @@ class KanbanUserstoriesService extends taiga.Service
         @.refresh()
 
     move: (usList, statusId, index) ->
+
         initialLength = usList.length
 
         usByStatus = _.filter @.userstoriesRaw, (it) =>
@@ -123,7 +124,13 @@ class KanbanUserstoriesService extends taiga.Service
         setPreviousOrders = []
         setNextOrders = []
 
-        if !previous
+        isArchivedHiddenStatus = @.archivedStatus.indexOf(statusId) != -1 &&
+            @.statusHide.indexOf(statusId) != -1
+
+        if isArchivedHiddenStatus
+            startIndex = new Date().getTime()
+
+        else if !previous
             startIndex = 0
         else if previous
             startIndex = @.order[previous.id] + 1


### PR DESCRIPTION
In this pull request there are 3 changes, a feature and two bug fixes:

- In kanban, when a US is dragged to a closed and hidden column, put it at the bottom. This feature is convenient and saves a long database query to reorder every previously archived US.

- Fix bug that prevents to put a US first in a kanban column.

- Fix bug on to reordering US in the backlog.
