### PR TITLE
monent locale zh-cn load failed fixed

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -555,6 +555,13 @@ gulp.task("coffee", function() {
 });
 
 gulp.task("moment-locales", function() {
+    gulp.src(paths.modules + "moment/locale/zh-cn.js")
+        .pipe(gulpif(isDeploy, uglify()))
+        .pipe(rename(function (path) {
+            path.basename = "zh-hans";
+        }))
+        .pipe(gulp.dest(paths.distVersion + "locales/moment-locales/"));
+
     return gulp.src(paths.modules + "moment/locale/*")
         .pipe(gulpif(isDeploy, uglify()))
         .pipe(gulp.dest(paths.distVersion + "locales/moment-locales/"));


### PR DESCRIPTION
"zh-hans" locale of taiga is "zh-hans", but for moment is "zh-cn",so copy zh-cn.js to zh-hans.js