### PR TITLE
Bug fix. Assigned users on userstory creation lightbox

### DIFF
--- a/app/modules/components/assigned/assigned-users-inline.directive.coffee
+++ b/app/modules/components/assigned/assigned-users-inline.directive.coffee
@@ -67,7 +67,11 @@ $translate, $compile, $currentUserService, avatarService, $userListService) ->
                 currentAssignedTo = null
             else if currentAssignedIds.indexOf(currentAssignedTo) == -1 || !currentAssignedTo
                 currentAssignedTo = currentAssignedIds[0]
-            $model.$modelValue.setAttr('assigned_users', currentAssignedIds)
+
+            if (!$model.$modelValue.assigned_users)
+                $model.$modelValue.assigned_users = currentAssignedIds
+            else
+                $model.$modelValue.setAttr('assigned_users', currentAssignedIds)
             $model.$modelValue.assigned_to = currentAssignedTo
 
         $el.on "click", ".users-dropdown", (event) ->


### PR DESCRIPTION
[#5715 [FRONT] [Kanban] Doesn't add multiple users to a given user story ](https://tree.taiga.io/project/taiga/issue/5715)

