### PR TITLE
Add way to configure type of attachment allowed 

### DIFF
--- a/app/modules/resources/attachments-resource.service.coffee
+++ b/app/modules/resources/attachments-resource.service.coffee
@@ -72,7 +72,7 @@ Resource = (urlsService, http, config, $rootScope, $q, storage) ->
         maxFileSize = config.get("maxUploadFileSize", null)
         allow_type = config.get("allowAttachmentType", null)
 
-        file_extension = file.name.split(".")[1]
+        file_extension = file.name.split(".")[1].toLowerCase()
 
 
         if allow_type and allow_type.length > 0 and !(file_extension in allow_type)

--- a/app/modules/resources/attachments-resource.service.coffee
+++ b/app/modules/resources/attachments-resource.service.coffee
@@ -70,6 +70,21 @@ Resource = (urlsService, http, config, $rootScope, $q, storage) ->
             return defered.promise
 
         maxFileSize = config.get("maxUploadFileSize", null)
+        allow_type = config.get("allowAttachmentType", null)
+
+        file_extension = file.name.split(".")[1]
+
+
+        if allow_type and allow_type.length > 0 and !(file_extension in allow_type)
+           response = {
+               status: 413,
+               data: _error_message: "'#{file_extension}' type is not supported"
+           }
+           defered.reject(response)
+           return defered.promise
+
+
+
 
         if maxFileSize and file.size > maxFileSize
             response = {

--- a/conf/conf.example.json
+++ b/conf/conf.example.json
@@ -16,6 +16,7 @@
     "termsOfServiceUrl": null,
     "GDPRUrl": null,
     "maxUploadFileSize": null,
+    "allowAttachmentType":[],
     "contribPlugins": [],
     "tribeHost": null,
     "importers": [],


### PR DESCRIPTION
his enhancement adds the ability to configure allowed type of attachment. The configuration will be done in conf.json through the parameter allowAttachmentType , it will take in a list of file extensions(case insensitive).