### PR TITLE
:sparkles: Add special styling for closed user stories in the taskboard.

### DIFF
--- a/app/partials/includes/modules/taskboard-table.jade
+++ b/app/partials/includes/modules/taskboard-table.jade
@@ -50,7 +50,7 @@ div.taskboard-table(
                         ng-class='{hidden:!usFolded[us.id]}'
                     )
 
-                    h3.us-title
+                    h3.us-title(ng-class='{blocked: us.is_blocked, closed: us.is_closed}')
                         a(href="",
                           tg-nav="project-userstories-detail:project=project.slug,ref=us.ref",
                           tg-nav-get-params="{\"milestone\": {{us.milestone}}}",

--- a/app/styles/modules/backlog/taskboard-table.scss
+++ b/app/styles/modules/backlog/taskboard-table.scss
@@ -148,10 +148,10 @@ $column-padding: .5rem 1rem;
         margin-bottom: .25rem;
         min-height: 10rem;
         width: 100%;
+
         &.blocked {
             .taskboard-row-title-box {
                 background: rgba($red, .6);
-
             }
             .taskboard-row-title-box svg,
             .taskboard-row-title-box svg:hover,
@@ -236,6 +236,15 @@ $column-padding: .5rem 1rem;
         @include font-type(text);
         margin-bottom: 0;
         margin-right: 3rem;
+
+        &.closed {
+            color: lighten($gray-light, 30%);
+            text-decoration: line-through;
+
+            a {
+                color: lighten($gray-light, 30%);
+            }
+        }
     }
     .status-value {
         @include font-size(small);


### PR DESCRIPTION
This makes user story titles have a strikethrough style, along with a
lighter colored gray, when the story they represent is in the CLOSED state.

Fixes taigaio/taiga-front#1381.