### PR TITLE
:bug: Make gulp-cache tmp directory username-dependent.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ var gulp = require("gulp"),
     templateCache = require("gulp-angular-templatecache"),
     runSequence = require("run-sequence"),
     order = require("gulp-order"),
+    os = require('os'),
     print = require('gulp-print'),
     del = require("del"),
     livereload = require('gulp-livereload'),
@@ -271,6 +272,8 @@ gulp.task("scss-lint", [], function() {
 
     var sassFiles = paths.sass.concat(themes.current.customScss, ignore);
 
+    var tmpDir = 'gulp-cache-' + os.userInfo().username;
+
     return gulp.src(sassFiles)
         .pipe(gulpif(!isDeploy, cache(scsslint({endless: true, sync: true, config: ".scss-lint.yml"}), {
           success: function(scsslintFile) {
@@ -280,7 +283,11 @@ gulp.task("scss-lint", [], function() {
             return {
               scsslint: scsslintFile.scsslint
             };
-          }
+          },
+          fileCache: new cache.Cache({
+            tmpdir: os.tmpdir(),
+            cacheDirName: tmpDir
+          })
         })))
         .pipe(gulpif(fail, scsslint.failReporter()));
 });


### PR DESCRIPTION
Previous to this commit, there is a possibility that when one user on a
given system runs `gulp scss-lint`, followed by a _different_ user running
the same command, the gulp task will error because the second user doesn't
have permissions to delete /tmp/gulp-cache. To fix this, this commit
appends the current user's name to the temporary directory being used for
the cache. This effectively busts the cache for different users on the same
system.

Refs taigaio/taiga-front#1416.