### PR TITLE
fix overflow issue in kanban headers

### DIFF
--- a/app/styles/modules/kanban/kanban-table.scss
+++ b/app/styles/modules/kanban/kanban-table.scss
@@ -68,7 +68,7 @@ $column-padding: .5rem 1rem;
     position: relative;
     .kanban-table-inner {
         display: flex;
-        overflow: hidden;
+        overflow: visible;
         position: absolute;
         width: 100%;
     }


### PR DESCRIPTION
This fixes the issue described in taigaio/taiga-front#1305. In brief, the `hidden` overflow value for the `kanban-table-inner` class was causing display issues when the number of columns in a kanban board exceeded the screen width.