### PR TITLE
Fix default order for comments

### DIFF
--- a/app/modules/history/history.controller.coffee
+++ b/app/modules/history/history.controller.coffee
@@ -34,7 +34,7 @@ class HistorySectionController
         @.editMode = {}
         @.viewComments = true
 
-        @.reverse = @storage.get("orderComments")
+        @.reverse = @storage.get("orderComments", true)
 
         taiga.defineImmutableProperty @, 'disabledActivityPagination', () =>
             return @activityService.disablePagination


### PR DESCRIPTION
In old Taiga versions, the last comment are placed at the bottom of issue page. After Taiga upgrade, users can change the comments order (nice!). The problem comes with the new default order (now, last comment are in top of the list).

I think last comment should be placed in bottom of the page by default, for two reasons:

1) For consistency with old versions. With the new order, most of our users are really confused.

2) From UX perspective, the last comment should be placed next to add-comment form, on bottom of the issue page. This way, you can easily read the comment you are answering (usually one of the last comments).