### PR TITLE
Fix main nav items icons vertical centering

### DIFF
--- a/app/styles/modules/common/nav.scss
+++ b/app/styles/modules/common/nav.scss
@@ -79,6 +79,7 @@ tg-project-menu {
         display: none;
     }
     .icon {
+        display: block;
         font-size: 1.5rem;
         line-height: 2.2rem;
     }


### PR DESCRIPTION
## System
**SO**: Ubuntu 19
**Browser**: Chrome
**Browser version**: 77.0.3865.75 (Official Build) (64-bit)

## Description
The `display: inline-block` property value renders a little bit more space than the actual
element size because it is `inline` and inline elements are affected by the `line-height`
property that usually is set to `1.2em`.
We do not want this behavior here because the main-nav icons are not placed with
other inline items so we can set their display property to `block` so the icon will be correctly
centered into the nav item.

## How to reproduce
Enter into taiga project and mouseover a main nav item so you can see that the icon is not
centered.

## Screenshots
**Before**
![image](https://user-images.githubusercontent.com/2527191/64761079-830d8980-d53b-11e9-85d2-a6550fd2f50f.png)
**After**
![image](https://user-images.githubusercontent.com/2527191/64761144-adf7dd80-d53b-11e9-84bd-ae2c24071b7f.png)
