### PR TITLE
centers counter

### DIFF
--- a/app/styles/components/buttons.scss
+++ b/app/styles/components/buttons.scss
@@ -253,6 +253,9 @@
         position: absolute;
         top: -.5rem;
         width: 1rem;
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
     }
 }
 


### PR DESCRIPTION
I've just written this via browser-dev-tools (latest Chromium on Linux). Not tested in local development or other browsers *(flex is well supported though)*.

If centering the number is something more complicated, maybe it makes more sense to just decline this proposal, as I probably won't clone the whole project for this :hear_no_evil:

before:
![2019-11-26_ 14-05-58 screenshot btn-filter 1](https://user-images.githubusercontent.com/4787651/69636665-66bbbc00-1057-11ea-886e-473e4bcc26ec.png)

after:
![2019-11-26_ 14-06-26 screenshot btn-filter 2](https://user-images.githubusercontent.com/4787651/69636676-6c190680-1057-11ea-8d38-522b05f2e761.png)

How to test:
- create kanban board
- create task with tag
- click on filter-button on top *right*
- => drawer opens on *left* side
- set tag as filter
- => filter-button now has a label with a counter for active filtes
- => the label is centered *(see screenshots above)*