### PR TITLE
Enhanced WYSIWYG: Show full name in user mentions

### DIFF
--- a/app/js/medium-mention.js
+++ b/app/js/medium-mention.js
@@ -246,7 +246,7 @@ var MentionExtension = MediumEditor.Extension.extend({
                 li.innerText = '#' + it.ref + ' - ' + it.subject;
             } else {
                 if (it.full_name) {
-                    li.innerText = '@' + it.full_name + ` (${it.username})`;
+                    li.innerText = '@' + it.full_name + ' (' + it.username + ')';
                 } else {
                     li.innerText = '@' + it.username;
                 }

--- a/app/js/medium-mention.js
+++ b/app/js/medium-mention.js
@@ -245,7 +245,11 @@ var MentionExtension = MediumEditor.Extension.extend({
             } else if (it.ref) {
                 li.innerText = '#' + it.ref + ' - ' + it.subject;
             } else {
-                li.innerText = '@' + it.username;
+                if (it.full_name) {
+                    li.innerText = '@' + it.full_name + ` (${it.username})`;
+                } else {
+                    li.innerText = '@' + it.username;
+                }
             }
 
             li.addEventListener('mousedown', this.selectMention.bind(this, it));


### PR DESCRIPTION
The WYSIWYG editor has been enhanced by the following changes:

  * The auto-completion popup now shows the `full_name` attribute for users if the field is available. Otherwise, it falls back to the username. This is an edge-case check for situations when an admin has removed the `full_name` field for some reason.
  * The WYSIWYG renders the `full_name` with an `@` prefix for the user. Upon saving the rendered `full_name` is swapped for the underlying `username` which gets saved to the database.
( see line 55-57 in app/modules/components/wysiwyg/wysiwyg.service.coffee )
