### PR TITLE
[issues/1385] Set gravatar default value to false

### DIFF
--- a/conf/conf.example.json
+++ b/conf/conf.example.json
@@ -20,6 +20,6 @@
     "contribPlugins": [],
     "tribeHost": null,
     "importers": [],
-    "gravatar": true,
+    "gravatar": false,
     "rtlLanguages": ["fa"]
 }


### PR DESCRIPTION
See #1385

During development, the gravatar integration will not work when set to true because the instance is not publicly visible.
Since development servers are accessed through the loopback interface, this will result in missing avatars for developers.

I'd like to start a discussion about this issue, and please let me know if I'm missing something to understand the root cause of this problem!