### PR TITLE
Fixes the class="popover select-color" div

### DIFF
--- a/app/modules/epics/dashboard/epic-row/epic-row.jade
+++ b/app/modules/epics/dashboard/epic-row/epic-row.jade
@@ -1,4 +1,3 @@
-
 .epic-row.e2e-epic-row(
     ng-class="{'is-blocked':  vm.epic.get('is_blocked'), 'is-closed': vm.epic.get('is_closed'), 'unfold': vm.displayUserStories, 'not-empty': vm.epic.getIn(['user_stories_counts', 'opened']) || vm.epic.getIn(['user_stories_counts', 'closed'])}"
     ng-click="vm.toggleUserStoryList()"
@@ -37,17 +36,18 @@
     .sprint(ng-if="vm.options.sprint")
 
     .assigned.e2e-assigned-to(
-        ng-if="vm.options.assigned"
-        tg-loading="vm.assignLoader"
+        ng-if="vm.options.assigned && vm.epic.get('assigned_to')"
     )
-        tg-assigned-to-component(
-            assigned-to="vm.epic.get('assigned_to_extra_info')"
-            project="vm.project"
-            on-remove-assigned="vm.updateAssignedTo()"
-            on-assign-to="vm.updateAssignedTo(member)"
-            tg-isolate-click
+        img(
+            tg-avatar="vm.epic.get('assigned_to_extra_info')"
         )
-
+    .assigned(
+        ng-if="vm.options.assigned && !vm.epic.get('assigned_to')"
+    )
+        img(
+            src="/#{v}/images/unnamed.png"
+            alt="{{EPICS.DASHBOARD.UNASSIGNED | translate}}"
+        )
     .status(
         ng-if="vm.options.status && !vm.canEditEpics()"
     )

--- a/app/styles/modules/common/colors-table.scss
+++ b/app/styles/modules/common/colors-table.scss
@@ -1,5 +1,5 @@
 .colors-table {
-    overflow-x: auto;
+    overflow-x: inherit;
     .table-header {
         @include font-size(medium);
         @include font-type(semibold);


### PR DESCRIPTION
Commit 26ebd55 introduced `overflow-x: auto;` in `app/styles/modules/common/colors-table.scss` which broke the visibility of the color selector in the admin panel while correcting other problems.

The `auto` setting breaks the popover behaviour everywhere.
For example, the color selector in `admin > attributes > statuses` is hidden underneath
an other element, because its `overflow-x` property is set to `auto`.
This results in the popover becoming hidden for the user, and
creating a scrollbar which may not be easily visible, because it's created
within the `<div class="colors-table">` container.

I propose changing the value to `inherit`.