### PR TITLE
US status preview to backlog sprint table

### DIFF
--- a/app/partials/includes/modules/sprint.jade
+++ b/app/partials/includes/modules/sprint.jade
@@ -32,6 +32,8 @@ div.sprint-table(tg-bind-scope, ng-class="{'sprint-empty-wrapper': !sprint.user_
                 )
         div.column-points.width-1(tg-bo-bind="us.total_points",
                                   ng-class="{closed: us.is_closed, blocked: us.is_blocked}")
+        div.column-status(tg-bo-title="us.status_extra_info.name"
+                          ng-style="{'background-color': us.status_extra_info.color}")
 
 a.button-gray.button-block(title="{{ 'BACKLOG.SPRINTS.TITLE_LINK_TASKBOARD' | translate: {\"name\": sprint.name} }}",
               tg-nav="project-taskboard:project=project.slug,sprint=sprint.slug",

--- a/app/styles/modules/backlog/sprints.scss
+++ b/app/styles/modules/backlog/sprints.scss
@@ -164,7 +164,6 @@
                 opacity: .9;
                 transition: background .2s ease-in;
             }
-
         }
         .gu-transit {
             background: lighten($gray-light, 12%);
@@ -175,7 +174,7 @@
         }
         .column-us {
             @include font-size(small);
-            flex-flow: 3;
+            flex-grow: 3;
             padding: 0 4px;
         }
         .us-name {
@@ -197,6 +196,10 @@
             &.blocked {
                 color: $red;
             }
+        }
+        .column-status {
+            flex: 0 0 .5rem;
+            margin-left: 4px;
         }
         &.sprint-empty-wrapper { // hide dragging items
             .row {


### PR DESCRIPTION
Simple UI enhancement to preview US statuses in the sprint table in backlog since they disappear from view after being assigned to a sprint. The colors follow the project settings dynamically.

It is somewhat redundant with the kanban feature but one could argue it is nice to have if you're working mainly with the backlog page. Here's a preview of what this looks like:

![Preview](https://user-images.githubusercontent.com/47317085/81069890-ccec1b00-8ee2-11ea-9673-73371c9e7936.png)

