### PR TITLE
fix: Github Import design

### DIFF
--- a/app/modules/projects/create/github-import/github-import-project-form/github-import-project-form.scss
+++ b/app/modules/projects/create/github-import/github-import-project-form/github-import-project-form.scss
@@ -3,7 +3,7 @@
 }
 
 .create-project-github-import-type {
-    margin-bottom: 1rem;
+    margin-bottom: 5rem;
     text-align: center;
 
     p {
@@ -57,5 +57,12 @@
     &-description {
         @include font-type(light);
         @include font-size(small);
+    }
+
+    .template-issues {
+        color: $black;
+    }
+    .template-public {
+        display: flex;
     }
 }


### PR DESCRIPTION
fix: Github Import design to close #1911

![image](https://user-images.githubusercontent.com/6967675/81754165-be3ece80-94b5-11ea-88f8-d13eac379afb.png)

Signed-off-by: mathieu.brunot <mathieu.brunot@monogramm.io>