### PR TITLE
Addition of possibility to modify a title of a wiki link.

### DIFF
--- a/app/partials/wiki/wiki-nav.jade
+++ b/app/partials/wiki/wiki-nav.jade
@@ -21,6 +21,11 @@ ul.sortable.wiki-link-container
         <% } %>
         a.link-title(title!="{{ link.title }}", href!="{{ link.url }}") {{ link.title }}
 
+        <% if (modifyWikiLinkPermission) { %>
+        a.js-modify-link.modify-wiki-page(title!="{{'WIKI.MODIFY_LINK_TITLE' | translate}}")
+            tg-svg(svg-icon="icon-drag")
+        <% } %>
+        
         <% if (deleteWikiLinkPermission) { %>
         a.js-delete-link.remove-wiki-page(title!="{{'WIKI.DELETE_LINK_TITLE' | translate}}")
             tg-svg(svg-icon="icon-trash")

--- a/app/styles/modules/wiki/wiki-nav.scss
+++ b/app/styles/modules/wiki/wiki-nav.scss
@@ -68,6 +68,12 @@
             transition: opacity .2s linear;
             transition-delay: .1s;
         }
+        .modify-wiki-page {
+            cursor: pointer;
+            opacity: 1;
+            transition: opacity .2s linear;
+            transition-delay: .1s;
+        }
         .dragger {
             cursor: move;
             opacity: 1;
@@ -109,4 +115,13 @@
             }
         }
     }
+    .modify-wiki-page {
+        opacity: 0;
+        &:hover {
+            .icon {
+                fill: $red;
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
With this merge request I'm implementing the possibility to modify a wiki link title.
Hovering over a wiki link, next to the trash icon that was already appearing before, it will appear now a new option that let the user modify the title of a wiki link.

If this functionality is approved  I would add in this merge request: 

1. the translation for two new translation keys:
*WIKI.MODIFY_LINK_TITLE
*WIKI.MODIFY_LINK_SUBTITLE

2. an svg icon in the sprites.svg for the new action. I would suggest a cog.
3. I could implement in the backend a functionality for updating the href from the title.

Small note: currently when adding a wiki link, there appears a hidden input box just below the other wiki links. I could have reused this functionality but I considered it better from the UX point of view, to use a dialog that the focus attention on the user on the only information that is changing.
To reach that goal, I implemented a new confirmation logic, called *askValue* that is very similar to askDelete, with the addition of an input box. This logic perhaps could be reused in the future in other case.
Thanks