### PR TITLE
Fixed linter errors in existing themes

### DIFF
--- a/app/themes/high-contrast/custom.scss
+++ b/app/themes/high-contrast/custom.scss
@@ -16,26 +16,26 @@ tg-project-menu {
     .nav-right {
         a:hover,
         a.active {
-            background: white;
-            color: black;
-            svg{
-                fill: black;
-                stroke:black;
+            background: $white;
+            color: $black;
+            svg {
+                fill: $black;
+                stroke: $black;
             }
         }
         svg {
-            fill: white;
-            stroke: white;
+            fill: $white;
+            stroke: $white;
         }
         .active svg {
-            fill: black;
-            stroke:black;
+            fill: $black;
+            stroke: $black;
         }
     }
 }
 
 .button-gray {
-    background: black;
+    background: $black;
 }
 .more-attachments {
     span {
@@ -55,10 +55,10 @@ tg-project-menu {
 .ticket-detail-settings .item-block,
 .ticket-detail-settings .item-unblock,
 .ticket-detail-settings .promote-button {
-    background: black;
-    color: white;
+    background: $black;
+    color: $white;
     * {
-        color: white;
+        color: $white;
     }
 }
 
@@ -79,29 +79,29 @@ a,
 .menu-tertiary {
     ul li a.active,
     ul li a:hover {
-        background: black;
-        color: white;
+        background: $black;
+        color: $white;
     }
 }
 
 .lb-user-list .user-list-item.is-active {
-    background: grey;
-    color: white;
+    background: $gray;
+    color: $white;
     * {
-        color: white;
+        color: $white;
     }
 }
 
 .taskboard-actions {
-    background: grey;
+    background: $gray;
 }
 
 .card {
-    border: 1px solid black;
+    border: 1px solid $black;
 }
 
 //// OVERRIDE
 
 .topnav-dropdown-wrapper .counter {
-    color: black;
+    color: $black;
 }

--- a/app/themes/material-design/custom.scss
+++ b/app/themes/material-design/custom.scss
@@ -4,7 +4,7 @@
         background: url('../images/menu-vert.png') repeat top left;
     }
     .nav-right {
-        a:hover svg{
+        a:hover svg {
             fill: rgba(255, 255, 255, .7);
             stroke: rgba(255, 255, 255, .7);
         }
@@ -13,8 +13,8 @@
             stroke: rgba(255, 255, 255, .5);
         }
         .active svg {
-            fill: #A83F60;
-            stroke:#A83F60;
+            fill: $red-frambuesa;
+            stroke: $red-frambuesa;
         }
     }
 }
@@ -41,5 +41,5 @@ tg-project-menu {
 //// OVERRIDE
 
 .topnav-dropdown-wrapper .counter {
-    color: #A83F60;
+    color: $red-frambuesa;
 }

--- a/app/themes/material-design/variables.scss
+++ b/app/themes/material-design/variables.scss
@@ -47,6 +47,7 @@ $primary-background: $primary-25;
 $secondary-light: $secondary-50;
 $secondary-dark: #1a237e;
 $red-light: $red-25;
+$red-frambuesa: #a83f60;
 
 // Status colors
 $green-light: #91DF85;

--- a/app/themes/taiga-legacy/custom.scss
+++ b/app/themes/taiga-legacy/custom.scss
@@ -23,9 +23,9 @@ tg-project-menu {
     background-color: $primary-dark;
     background-image: url('../images/menu.png');
 }
-.menu-tertiary  ul li a,
-.menu-tertiary  ul li a:hover {
-    color: white;
+.menu-tertiary ul li a,
+.menu-tertiary ul li a:hover {
+    color: $white;
 }
 
 .button-green {
@@ -42,7 +42,8 @@ tg-project-menu {
 .button-red {
     @include font-type(light);
 }
-.button-green, .button-gray {
+.button-green,
+.button-gray {
     &:hover,
     &.active,
     &:visited:hover {


### PR DESCRIPTION
These are simply formatting and syntax tweaks to make the linter happy.  No color, style or formatting changes.  The errors were causing git hook failures while working on a custom theme branch.

Before:

```
app/themes/material-design/custom.scss
  7:19  ✖  Expected single space before "{"                                 block-opening-brace-space-before
 16:19  ✖  Expected "#A83F60" to be "#a83f60"                               color-hex-case
 16:19  ✖  Unexpected hex color "#A83F60"                                   color-no-hex
 17:20  ✖  Expected "#A83F60" to be "#a83f60"                               color-hex-case
 17:20  ✖  Unexpected hex color "#A83F60"                                   color-no-hex
 17:20  ✖  Expected single space after ":" with a single-line declaration   declaration-colon-space-after
 44:12  ✖  Expected "#A83F60" to be "#a83f60"                               color-hex-case
 44:12  ✖  Unexpected hex color "#A83F60"                                   color-no-hex
```

```
app/themes/taiga-legacy/custom.scss
 26:15  ✖  Unexpected "  "                  selector-descendant-combinator-no-non-space
 27:15  ✖  Unexpected "  "                  selector-descendant-combinator-no-non-space
 28:12  ✖  Unexpected named color "white"   color-named
 45:14  ✖  Expected newline after ","       selector-list-comma-newline-after
```

After:

Well, those warnings/errors are gone when compiling/deploying.