### PR TITLE
[TAIGA 6] Add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:1.19-alpine
+LABEL maintainer="support@taiga.io"
+
+RUN apk update \
+    && wget https://github.com/taigaio/taiga-front-dist/archive/master.zip \
+    && unzip master.zip \
+    && mv taiga-front-dist-master/dist/* /usr/share/nginx/html \
+    && rm -rf taiga-front-dist-master

--- a/docker/notes.md
+++ b/docker/notes.md
@@ -1,0 +1,5 @@
+This image doesn't need local context to build, so you can just:
+
+```sh
+$ docker build -t IMAGE_TAG - < docker/Dockerfile
+```


### PR DESCRIPTION
![](https://media.giphy.com/media/lqdJsUDvJnHBgM82HB/giphy-downsized.gif)

Dockerfile for the win! This PR adds a Dockerfile to build a docker image with the front.
I've already pushed an image to taigaio/packages and it's already used from the repo:taiga-deploy

To test:
- [x] build the image: `docker build -t taiga-front:latest - < docker/Dockerfile`
- [x] run the image: `docker run --rm -ti taiga-front:latest /bin/sh` and check the compiled taiga is in `/usr/share/nginx/html`
- [x] run the entire taiga environment with repo:taiga-deploy `docker-compose up -d`
- [x] close tasks 537 and 538 