### PR TITLE
Add contrib slack

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,18 @@ LABEL maintainer="support@taiga.io"
 COPY docker/default.conf /etc/nginx/conf.d/default.conf
 
 RUN apk update \
+    && apk add --no-cache --virtual .build-deps \
+       subversion \
+    # Install taiga-front core
     && wget https://github.com/taigaio/taiga-front-dist/archive/master.zip \
     && unzip master.zip \
+    # Install taiga-front contribs
+    && mkdir taiga-front-dist-master/dist/plugins \
+    && cd taiga-front-dist-master/dist/plugins \
+    && svn export "https://github.com/taigaio/taiga-contrib-slack/tags/5.5.1/front/dist" "slack" \
+    && cd / \
+    # Remove unused dependencies
+    && apk del --no-cache .build-deps \
+    # Ready for nginx
     && mv taiga-front-dist-master/dist/* /usr/share/nginx/html \
     && rm -rf taiga-front-dist-master


### PR DESCRIPTION
![](https://media.giphy.com/media/3o6ozmlzlH8YQdr9GU/giphy.gif)

This PR adds `taiga-contrib-slack` to the Dockerfile. To test:

- [x] build a new front image
- [x] in repo:taiga-deploy go to branch `U/468/T/594/add_slack_contrib` (same name, yes)
- [x] launch everything with `docker-compose up -d`
- [x] go to project > settings > plugins and check there is a `slack` tab
- [ ] merge as well PR https://github.com/taigaio/taiga-deploy/pull/2
- [ ] move task 594 to ready for QA
