### PR TITLE
Serve taiga-front as an SPA

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!docker/default.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM nginx:1.19-alpine
 LABEL maintainer="support@taiga.io"
 
+COPY docker/default.conf /etc/nginx/conf.d/default.conf
+
 RUN apk update \
     && wget https://github.com/taigaio/taiga-front-dist/archive/master.zip \
     && unzip master.zip \

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80 default_server;
+
+    client_max_body_size 100M;
+    charset utf-8;
+
+    access_log /var/log/nginx/taiga6-front.access.log;
+    error_log /var/log/nginx/taiga6-front.error.log;
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/docker/notes.md
+++ b/docker/notes.md
@@ -1,5 +1,0 @@
-This image doesn't need local context to build, so you can just:
-
-```sh
-$ docker build -t IMAGE_TAG - < docker/Dockerfile
-```


### PR DESCRIPTION
![](https://media.giphy.com/media/xT0BKEbS571e53UIDe/giphy.gif)

Configure docker image to serve an SPA

- [x] compile the image to use the new version: `docker build -f docker/Dockerfile -t taigaio/taiga-front:alpha .`
- [x] launch services with `docker-compose up -d`
- [x] go to user>profile. Press F5, it should work as expected (reloading the page)
- [x] move task 644 to ready for QA