### PR TITLE
Move issues to another project

### DIFF
--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -174,6 +174,12 @@
         "DUE_DATE": {
             "TITLE_ACTION_SET_DUE_DATE": "Set due date"
         },
+        "CHANGE_PROJECT": {
+            "MOVE_TO_ANOTHER_PROJECT": "Move to another project",
+            "NO_PROJECTS": "There are no projects available",
+            "SELECT_DESTINATION_PLACEHOLDER": "Select destination",
+            "WHICH_PROJECT": "Which project?"
+        },
         "ASSIGNED_USERS": {
             "ADD": "Select assigned user",
             "ADD_ASSIGNED": "Add assigned",

--- a/app/modules/components/change-project/change-project-lb/change-project-lb.controller.coffee
+++ b/app/modules/components/change-project/change-project-lb/change-project-lb.controller.coffee
@@ -1,0 +1,89 @@
+###
+# Copyright (C) 2014-2018 Taiga Agile LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# File: components/change-project/change-project-lb/change-project-lb.controller.coffee
+###
+
+module = angular.module("taigaComponents")
+
+class ChangeProjectLightboxController
+    @.$inject = [
+        'tgProjectService'
+        '$tgResources'
+        '$tgRepo'
+        '$tgNavUrls'
+        '$tgLocation'
+        'lightboxService'
+        '$window'
+    ]
+
+    constructor: (
+        @projectService
+        @rs
+        @repo
+        @navUrls
+        @location
+        @lightboxService
+        @window
+    ) ->
+        @.projectId = @projectService.project.get('id')
+        @.loading = false
+        @.selectedProjectId = null
+        @._loadProjects()
+
+    _loadProjects: () ->
+        @rs.projects.list().then (projects) =>
+            @.projects = _.filter(
+                projects, (p) =>
+                    p.id != @.projectId and
+                    p.is_issues_activated and
+                    p.my_permissions.indexOf("add_issue") != -1 and
+                    not p.blocked_code
+            )
+
+    submit: () ->
+        @.item.project = @.selectedProjectId
+
+        # set the attributes so they appear in _modifiedAttrs:
+        #
+        # The current backend implementation matches these fields by their
+        # name and slug to the new project. It is not possible to provide
+        # IDs of the corresponding models in the new project, the backend
+        # resets the entities not found in the existing project to default ones
+        # in the new project.
+        @.item.setAttr('milestone', @.item.milestone)
+        @.item.setAttr('status', @.item.status)
+        @.item.setAttr('priority', @.item.priority)
+        @.item.setAttr('severity', @.item.severity)
+        @.item.setAttr('type', @.item.type)
+
+        # alternatively, @repo.save(@.item, false) can be used:
+        # with patch=false, all values are send on save.
+        @repo.save(@.item).then (data) =>
+            detailPage = "project-#{@.item._name}-detail"
+            ctx = {
+                project: data.project_extra_info.slug
+                ref: data.ref
+            }
+            newUrl = @navUrls.resolve(detailPage, ctx)
+
+            # FIXME Although we reload the page fully, exceptions for all 5
+            # fields are thrown:
+            # Error: status is undefined
+            # TODO update item and services without reloading the page
+            @window.location.href = newUrl
+
+module.controller("ChangeProjectLbCtrl", ChangeProjectLightboxController)

--- a/app/modules/components/change-project/change-project-lb/change-project-lb.directive.coffee
+++ b/app/modules/components/change-project/change-project-lb/change-project-lb.directive.coffee
@@ -1,0 +1,41 @@
+###
+# Copyright (C) 2014-2018 Taiga Agile LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# File: components/change-project/change-project-lb/change-project-lb.directive.coffee
+###
+
+module = angular.module("taigaComponents")
+
+changeProjectLightboxDirective = (lightboxService) ->
+    link = (scope, el, attrs, ctrl) ->
+        lightboxService.open(el)
+
+    return {
+        scope: {}
+        bindToController: {
+            item: "="
+        },
+        templateUrl: "components/change-project/change-project-lb/change-project-lb.html"
+        controller: "ChangeProjectLbCtrl"
+        controllerAs: "vm"
+        link: link
+    }
+
+changeProjectLightboxDirective.$inject = [
+    "lightboxService"
+]
+
+module.directive("tgChangeProjectLb", changeProjectLightboxDirective)

--- a/app/modules/components/change-project/change-project-lb/change-project-lb.jade
+++ b/app/modules/components/change-project/change-project-lb/change-project-lb.jade
@@ -1,0 +1,29 @@
+tg-lightbox-close
+
+.change-project-container
+  .change-project-header
+    h2.title {{ 'COMMON.CHANGE_PROJECT.MOVE_TO_ANOTHER_PROJECT'|translate }}
+
+  .change-project-controls
+    p(ng-if="!vm.projects.length") {{ 'COMMON.CHANGE_PROJECT.NO_PROJECTS'|translate }}
+    div(ng-if="vm.projects.length > 0")
+      fieldset
+        label {{ 'COMMON.CHANGE_PROJECT.WHICH_PROJECT'|translate }}
+        select.project-select(
+            ng-model="vm.selectedProjectId"
+            ng-options="p.id as p.name for p in vm.projects"
+            id="project-selector-dropdown"
+            autofocus
+        )
+            option(
+                value=""
+                disabled
+                selected
+                translate="COMMON.CHANGE_PROJECT.SELECT_DESTINATION_PLACEHOLDER"
+            )
+      button.button-green.move-button(
+          href=""
+          ng-click="vm.submit()"
+          translate="COMMON.SAVE"
+          ng-disabled="!(vm.selectedProjectId)"
+      )

--- a/app/modules/components/change-project/change-project-lb/change-project-lb.scss
+++ b/app/modules/components/change-project/change-project-lb/change-project-lb.scss
@@ -1,0 +1,23 @@
+.lightbox-change-project .change-project-container {
+    display: flex;
+    flex-direction: column;
+    max-width: 550px;
+    width: 100%;
+    .change-project-header {
+        margin: 0 auto;
+        max-width: 400px;
+        text-align: center;
+    }
+    .change-project-controls {
+        p {
+            margin-bottom: 2.5em;
+            text-align: center;
+        }
+        .project-select {
+            margin-top: .5em;
+        }
+        .move-button {
+            width: 100%;
+        }
+    }
+}

--- a/app/modules/components/change-project/change-project.controller.coffee
+++ b/app/modules/components/change-project/change-project.controller.coffee
@@ -1,0 +1,59 @@
+###
+# Copyright (C) 2014-2018 Taiga Agile LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# File: components/change-project/change-project-controller.coffee
+###
+
+taiga = @.taiga
+
+class ChangeProjectController
+    @.$inject = [
+        "$translate"
+        "tgLightboxFactory"
+        "tgProjectService"
+        "$rootScope"
+    ]
+
+    constructor: (@translate, @tgLightboxFactory, @projectService,  @rootscope) ->
+        @.disabled = false
+
+    # checkOpenItems: () ->
+    #     return _.some(Object.keys(@.openItems), (x) => @.openItems[x].length > 0)
+    #
+    # getProjects: () ->
+    #     return if !@.projects or @.permissions.indexOf("modify_issue") == -1
+    #     @.openItems.projects = []
+    #     @.projects.map (project) =>
+    #         if project.is_closed is false
+    #             @.openItems.projects.push({
+    #                 project_id: project.id
+    #             })
+    #     @.hasOpenItems = @checkOpenItems()
+
+    changeProject: () ->
+        if @.disabled is not true
+            @tgLightboxFactory.create(
+                "tg-change-project-lb",
+                {
+                    "class": "lightbox lightbox-change-project"
+                    "item": "item"
+                },
+                {
+                    "item": @.item
+                }
+            )
+
+angular.module('taigaComponents').controller('ChangeProjectCtrl', ChangeProjectController)

--- a/app/modules/components/change-project/change-project.directive.coffee
+++ b/app/modules/components/change-project/change-project.directive.coffee
@@ -1,0 +1,33 @@
+###
+# Copyright (C) 2014-2018 Taiga Agile LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# File: components/change-project/change-project.directive.coffee
+###
+
+module = angular.module("taigaComponents")
+
+changeProjectDirective = () ->
+    return {
+        controller: "ChangeProjectCtrl"
+        controllerAs: "vm"
+        bindToController: true
+        templateUrl: 'components/change-project/change-project.html'
+        scope: {
+            item: '=',
+        }
+    }
+
+module.directive('tgChangeProject', [changeProjectDirective])

--- a/app/modules/components/change-project/change-project.jade
+++ b/app/modules/components/change-project/change-project.jade
@@ -1,0 +1,4 @@
+a.move-to-other-project-button(
+  translate="COMMON.CHANGE_PROJECT.MOVE_TO_ANOTHER_PROJECT"
+  ng-click="vm.changeProject()"
+)

--- a/app/modules/components/detail/header/detail-header.controller.coffee
+++ b/app/modules/components/detail/header/detail-header.controller.coffee
@@ -81,4 +81,10 @@ class DetailHeaderController
             return item
         return transform.then(onEditSubjectSuccess, onEditSubjectError)
 
+    canChangeProject: () ->
+        return (
+            @.item._name == "issues" and
+            @.project.my_permissions.indexOf("modify_issue") != -1
+        )
+
 module.controller("DetailHeaderCtrl", DetailHeaderController)

--- a/app/modules/components/detail/header/detail-header.directive.coffee
+++ b/app/modules/components/detail/header/detail-header.directive.coffee
@@ -24,6 +24,12 @@ DetailHeaderDirective = () ->
 
     link = (scope, el, attrs, ctrl) ->
         ctrl._checkPermissions()
+        el.on "click", ".project-data", (event) ->
+            event.preventDefault()
+            event.stopPropagation()
+            return if not ctrl.canChangeProject()
+
+            el.find(".pop-change-project").popover().open()
 
     return {
         link: link,

--- a/app/modules/components/detail/header/detail-header.jade
+++ b/app/modules/components/detail/header/detail-header.jade
@@ -46,7 +46,18 @@
             tg-svg(svg-icon="icon-close")
 
 .detail-project
-    .project-name(ng-if="vm.project.name ") {{ vm.project.name }}
+    .project-data(ng-class="{clickable: vm.canChangeProject()}")
+        span.project-name(ng-if="vm.project.name ") {{ vm.project.name }}
+        span(ng-if="vm.canChangeProject()")
+            tg-svg(svg-icon="icon-arrow-down")
+            ul.popover.pop-change-project
+                li
+                    span.label
+                        tg-change-project(
+                            tg-check-permission="modify_issue",
+                            item="vm.item"
+                        )
+
     .section-name {{ vm.sectionName }}
 
 //- Blocked description

--- a/app/modules/components/detail/header/detail-header.scss
+++ b/app/modules/components/detail/header/detail-header.scss
@@ -27,7 +27,20 @@
             opacity: 1;
         }
     }
-
+    .project-data {
+        .popover {
+            @include popover(200px, 60px, 15px, '', '', 0, '', '', '', 15px, 'left');
+            text-transform: none;
+            li:hover a {
+                background: lighten($grey-02, 3%);
+            }
+        }
+        .icon {
+            height: .6rem;
+            margin: 0 0 .125rem .125rem;
+            width: .6rem;
+        }
+    }
     .detail-header-line {
         @include font-size(small);
         margin: .5rem 0 0;


### PR DESCRIPTION
This is a draft pull request to get feedback, if the general approach has a chance to be merged. See #487 
If this start is basically accepted, I'm willing to add tests and to finalize this PR according to your feedback and wishes.

Enhancement: In the issues detail view, a small dropdown arrow is visible if there are other selectable projects. Selectable projects are non-blocked scrum projects, where the current user has add_issue permissions. 

Although this is basically functional, I could not accomplish to properly update the issue in question and I use a page redirect/reload instead (setting $window.location.href) to avoid unwanted side effects. This might even be the way to go, as the URL of the issue changes. During the redirect, the browser console lists exceptions because of the references to the - necessarily modified - project specific fields on the issue instance. These do not cause bugs or inconsistencies. However, any help to avoid them is appreciated.

Note: No changes in taiga-back are required for this implementation. The current backend API already has some functionality to change the project of an issue, but also comes with some limitations. For example, the target fields (status, priority, type, severity and milestone) cannot be selected, but the request needs to contain the current fields of the issue. The backend maps them by slug or name to the resulting ones. If no matching field instance is found, the default is set. 
In the medium run, I'd rather add a new API route and a light box where the user can preview and change the resulting fields.

Feedback appreciated.