### PR TITLE
feat(conf importers): use bolean instead array to enable importers

### DIFF
--- a/app-loader/app-loader.coffee
+++ b/app-loader/app-loader.coffee
@@ -16,7 +16,10 @@ window.taigaConfig = {
     "privacyPolicyUrl": null,
     "termsOfServiceUrl": null,
     "maxUploadFileSize": null,
-    "importers": [],
+    "enableAsanaImporter": false,
+    "enableGithubImporter": false,
+    "enableJiraImporter": false,
+    "enableTrelloImporter": false,
     "contribPlugins": []
 }
 
@@ -82,3 +85,4 @@ promise.always ->
         ljs.load "/#{window._version}/js/app.js", ->
             emojisPromise.then ->
                 angular.bootstrap(document, ['taiga'])
+

--- a/app/modules/projects/create/import/import-project.controller.coffee
+++ b/app/modules/projects/create/import/import-project.controller.coffee
@@ -113,9 +113,12 @@ class ImportProjectController
         @.unfoldedOptions = options
 
     isActiveImporter: (importer) ->
-        if @config.get('importers').indexOf(importer) == -1
-            return false
-        return true
+        switch(importer)
+            when "asana" then @config.get('enableAsanaImporter')
+            when "github" then @config.get('enableGithubImporter')
+            when "jira" then @config.get('enableJiraImporter')
+            when "trello" then @config.get('enableTrelloImporter')
+            else return false
 
     cancelCurrentImport: () ->
         @location.url(@tgNavUrls.resolve('create-project-import'))

--- a/app/modules/projects/create/import/import-project.controller.spec.coffee
+++ b/app/modules/projects/create/import/import-project.controller.spec.coffee
@@ -24,7 +24,10 @@ describe "ImportProjectCtrl", ->
 
     _mockConfig = ->
         mocks.config = Immutable.fromJS({
-            importers: ['trello', 'github', 'jira', 'asana']
+            enableAsanaImporter: true,
+            enableGithubImporter: true,
+            enableJiraImporter: true,
+            enableTrelloImporter: true,
         })
 
         $provide.value("$tgConfig", mocks.config)

--- a/conf/conf.example.json
+++ b/conf/conf.example.json
@@ -20,7 +20,10 @@
     "contribPlugins": [],
     "tagManager": { "accountId": null },
     "tribeHost": null,
-    "importers": [],
+    "enableAsanaImporter": false,
+    "enableGithubImporter": false,
+    "enableJiraImporter": false,
+    "enableTrelloImporter": false,
     "gravatar": false,
     "rtlLanguages": ["fa"]
 }

--- a/docker/conf.json.template
+++ b/docker/conf.json.template
@@ -27,7 +27,10 @@
     "gitLabUrl": "${GITLAB_URL}",
     "tagManager": { "accountId": null },
     "tribeHost": null,
-    "importers": [],
+    "enableAsanaImporter": false,
+    "enableGithubImporter": false,
+    "enableJiraImporter": false,
+    "enableTrelloImporter": false,
     "gravatar": false,
     "rtlLanguages": ["fa"]
 }


### PR DESCRIPTION
![](https://media.giphy.com/media/CjmvTCZf2U3p09Cn0h/giphy.gif)

It is just a refactor. Change the settings of the importers to use booleans instead of an array of strings.

In `conf.json` change
```json
  importers: [
    "asana",
    "github",
    "jira",
    "trello"
  ],
```

by

```json
  enableAsanaImporter: true,
  enableGithubImporter: true,
  enableJiraImporter: true,
  enableTrelloImporter: true,
```