### PR TITLE
Remove obsolete config option

### DIFF
--- a/conf/conf.example.json
+++ b/conf/conf.example.json
@@ -15,7 +15,6 @@
     "supportUrl": "https://tree.taiga.io/support/",
     "privacyPolicyUrl": null,
     "termsOfServiceUrl": null,
-    "GDPRUrl": null,
     "maxUploadFileSize": null,
     "contribPlugins": [],
     "tagManager": { "accountId": null },


### PR DESCRIPTION
This option is not used anymore. It should have been removed on 4282c7a105778c62fa2e3c8d38ec1ef1633da085.