### PR TITLE
Add column "created" in "Issues" table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ e2e/screenshots/
 e2e/reports/
 app/modules/compile-modules/
 yarn.lock
+.vscode/

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -18,7 +18,6 @@
         "COPY_TO_CLIPBOARD": "Copy to clipboard",
         "COPIED_TO_CLIPBOARD": "Text has been copied to clipboard",
         "MOVE_TO_TOP": "Move to top",
-        "MOVE_TO_TOP": "Move to top",
         "EDIT": "Edit",
         "DRAG": "Drag",
         "TAG_LINE": "Your agile, free, and open source project management tool",
@@ -1609,6 +1608,7 @@
                 "STATUS": "Status",
                 "ATTACHMENTS": "Attachments",
                 "MODIFIED": "Modified",
+                "CREATED": "Created",
                 "ASSIGNED_TO": "Assign to"
             },
             "TITLE_ACTION_CHANGE_STATUS": "Change status",

--- a/app/locales/taiga/locale-it.json
+++ b/app/locales/taiga/locale-it.json
@@ -1606,6 +1606,7 @@
                 "VOTES": "Voti",
                 "STATUS": "Stato",
                 "ATTACHMENTS": "Allegati",
+                "CREATED": "Creato",
                 "MODIFIED": "Modificato",
                 "ASSIGNED_TO": "Assegna a"
             },

--- a/app/modules/components/issues-table/issues-table.jade
+++ b/app/modules/components/issues-table/issues-table.jade
@@ -111,6 +111,15 @@ section.issues-table.basic-table(ng-class="{empty: !ctrl.issues.length}")
                 path(
                     class="arrow-down"
                     d="M11.6232 9.42892C12.5713 9.42892 12.9872 10.6252 12.2435 11.2133L8.62027 14.0784C8.25672 14.3659 7.74328 14.3659 7.37973 14.0784L3.75652 11.2133C3.01283 10.6252 3.42868 9.42892 4.37679 9.42892H11.6232Z")
+        div.created-field(data-fieldname="created_date")
+            span {{"ISSUES.TABLE.COLUMNS.CREATED" | translate}}
+            svg(viewBox="0 0 16 16")
+                path(
+                    class="arrow-up"
+                    d="M11.6232 6.57199C12.5713 6.57199 12.9872 5.37569 12.2435 4.7876L8.62027 1.92248C8.25672 1.635 7.74328 1.635 7.37973 1.92248L3.75652 4.7876C3.01283 5.37569 3.42868 6.57199 4.37679 6.57199L11.6232 6.57199Z")
+                path(
+                    class="arrow-down"
+                    d="M11.6232 9.42892C12.5713 9.42892 12.9872 10.6252 12.2435 11.2133L8.62027 14.0784C8.25672 14.3659 7.74328 14.3659 7.37973 14.0784L3.75652 11.2133C3.01283 10.6252 3.42868 9.42892 4.37679 9.42892H11.6232Z")
         div.assigned-field(data-fieldname="assigned_to")
             span {{"ISSUES.TABLE.COLUMNS.ASSIGNED_TO" | translate}}
             svg(viewBox="0 0 16 16")
@@ -175,6 +184,10 @@ section.issues-table.basic-table(ng-class="{empty: !ctrl.issues.length}")
         div.modified-field(
             title="{{ issue.modified_date|momentFormat:'DD MMM YYYY HH:mm' }}"
         ) {{ issue.modified_date|momentFormat:'DD MMM YYYY'}}
+
+        div.created-field(
+            title="{{ issue.created_date|momentFormat:'DD MMM YYYY HH:mm' }}"
+        ) {{ issue.created_date|momentFormat:'DD MMM YYYY'}}
 
         div.assigned-field(tg-issue-assigned-to-inline-edition="issue")
             .issue-assignedto(title="{{'ISSUES.TABLE.TITLE_ACTION_ASSIGNED_TO' | translate}}")

--- a/app/modules/components/issues-table/issues/issues-table.scss
+++ b/app/modules/components/issues-table/issues/issues-table.scss
@@ -169,6 +169,7 @@
         }
     }
     .modified-field,
+    .created-field,
     .assigned-field,
     .attachments-field,
     .options-field,
@@ -184,6 +185,9 @@
         justify-content: flex-end;
     }
     .modified-field {
+        flex-basis: 100px;
+    }
+    .created-field {
         flex-basis: 100px;
     }
     .attachments-field {
@@ -242,7 +246,8 @@
         }
     }
     .level-field,
-    .modified-field {
+    .modified-field,
+    .created-field {
         @include until($widescreen) {
             display: none;
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "TaigaIO",
-  "version": "6.0.8",
+  "version": "6.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
With this MR I added a column "**created**" inside the issues table. In that column, it is possible to report the created date for a task.
Contextually, I modified the ```locale-en.json``` and ```locale-it.json``` files in order to enable the translation for the word "created" both in English and Italian.  \
Furthermore, I modified corresponding _scss_ files and updated the ```.gitignore``` for ignoring the .**vscode** folder.

This feature has to be tested with real data; I simply used sample data.