### PR TITLE
Add a default backlog ordering for new user stories

### DIFF
--- a/app/coffee/app.coffee
+++ b/app/coffee/app.coffee
@@ -401,6 +401,12 @@ configure = ($routeProvider, $locationProvider, $httpProvider, $provide, $tgEven
             section: "admin"
         }
     )
+    $routeProvider.when("/project/:pslug/admin/project-values/backlog-options",
+      {
+        templateUrl: "admin/admin-project-values-backlog-options.html",
+        section: "admin"
+      }
+    )
     $routeProvider.when("/project/:pslug/admin/memberships",
         {
             templateUrl: "admin/admin-memberships.html",

--- a/app/coffee/modules/admin/project-values.coffee
+++ b/app/coffee/modules/admin/project-values.coffee
@@ -26,6 +26,7 @@ joinStr = @.taiga.joinStr
 groupBy = @.taiga.groupBy
 bindOnce = @.taiga.bindOnce
 debounce = @.taiga.debounce
+scopeDefer = @.taiga.scopeDefer
 getDefaulColorList = @.taiga.getDefaulColorList
 
 module = angular.module("taigaAdmin")
@@ -1467,3 +1468,81 @@ ProjectSwimlanesWipDirective = () ->
     }
 
 module.directive("tgProjectSwimlanesWip", ProjectSwimlanesWipDirective)
+
+# #############################################################################
+# ## Scrum Options controller
+# #############################################################################
+
+BACKLOG_ORDER_OPTIONS = [
+    {
+      key: 1,
+      name: "ADMIN.PROJECT_BACKLOG_OPTIONS.TOP_OF_BACKLOG"
+    },
+    {
+      key: 0,
+      name: "ADMIN.PROJECT_BACKLOG_OPTIONS.BOTTOM_OF_BACKLOG"
+    }
+]
+
+class ProjectBacklogOptionsController extends taiga.Controller
+    @.$inject = [
+        "$scope",
+        "$rootScope",
+        "$tgRepo",
+        "$tgConfirm",
+        "$tgResources",
+        "$tgModel",
+        "tgProjectService"
+    ]
+
+    constructor: (@scope, @rootscope, @repo, @confirm, @rs, @model, @projectService) ->
+        @scope.project = @model.make_model("projects", @scope.project)
+        @scope.BACKLOG_ORDER_OPTIONS = BACKLOG_ORDER_OPTIONS
+
+    notifyBacklogOptionsUpdated: ->
+        @rootscope.$broadcast('admin:project-values:backlog-options:updated')
+
+module.controller("ProjectBacklogOptionsController", ProjectBacklogOptionsController)
+
+# #############################################################################
+# ## Scrum options directive
+# #############################################################################
+
+ProjectBacklogOptionsDirective = ($repo, $confirm, $loading, $navurls, $location, projectService, currentUserService, $analytics) ->
+    link = ($scope, $el, $attrs) ->
+        ctrl = $el.controller()
+        form = $el.find("form").checksley({"onlyOneErrorElement": true})
+        submit = debounce 2000, (event) =>
+            event.preventDefault()
+
+            return if not form.validate()
+
+            currentLoading = $loading()
+                .target(submitButton)
+                .start()
+
+            promise = $repo.save($scope.project)
+            promise.then ->
+                ctrl.notifyBacklogOptionsUpdated()
+                $confirm.notify("success")
+
+            promise.then null, (data) ->
+                form.setErrors(data)
+                if data._error_message
+                    $confirm.notify("error", data._error_message)
+
+        submitButton = $el.find(".submit-button")
+
+        $el.on "submit", "form", submit
+
+        $scope.$on "$destroy", ->
+            $el.off()
+
+    return {
+      link: link
+    }
+
+module.directive("tgProjectBacklogOptions",
+                 ["$tgRepo", "$tgConfirm", "$tgLoading", "$tgNavUrls",
+                  "$tgLocation", "tgProjectService", "tgCurrentUserService",
+                  "$tgAnalytics", ProjectBacklogOptionsDirective])

--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -183,11 +183,11 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         @scope.$on "sprint:us:moved", () =>
             @.loadSprints()
             @.loadProjectStats()
+            @.resetFirstStoryIndicator()
             @rootscope.$broadcast("filters:update")
 
         @scope.$on("backlog:load-closed-sprints", @.loadClosedSprints)
         @scope.$on("backlog:unload-closed-sprints", @.unloadClosedSprints)
-
     initializeSubscription: ->
         routingKey1 = "changes.project.#{@scope.projectId}.userstories"
         @events.subscribe @scope, routingKey1, (message) =>
@@ -331,6 +331,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
             # NOTE: Fix order of USs because the filter orderBy does not work propertly in the partials files
             @scope.userstories = @scope.userstories.concat(_.sortBy(userstories, "backlog_order"))
+            @.resetFirstStoryIndicator()
             @scope.visibleUserStories = _.map @scope.userstories, (it) ->
                 return it.ref
 
@@ -399,6 +400,8 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         @scope.usStatusById = groupBy(project.us_statuses, (x) -> x.id)
         @scope.usStatusList = _.sortBy(project.us_statuses, "id")
 
+        @.resetFirstStoryIndicator()
+
         return project
 
     loadInitialData: ->
@@ -420,11 +423,20 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
     prepareBulkUpdateData: (uses, field="backlog_order") ->
          return _.map(uses, (x) -> {"us_id": x.id, "order": x[field]})
 
+    resetFirstStoryIndicator: () ->
+      for us, key in @scope.userstories
+        @scope.userstories[key].is_first_in_backlog = false
+      if @scope.userstories.length > 0
+        @scope.userstories[0].is_first_in_backlog = true
+
+    moveUsToTopOfBacklogById: (id) ->
+      index = _.findIndex @scope.userstories, (us) ->
+        return us.id == id
+
+      @.moveUsToTopOfBacklog(@scope.userstories[index])
+
     moveUsToTopOfBacklog: (us) ->
       self = @
-      $('.first').each(() ->
-        $(this).removeClass('first');
-      )
       @.moveUs('sprint:us:move', [us], 0, null)
 
     # --move us api behavior--
@@ -617,7 +629,8 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
                 @q.all([
                     @.loadProjectStats(),
-                    @.loadSprints()
+                    @.loadSprints(),
+                    @.resetFirstStoryIndicator()
                 ])
             promise.then null, =>
                 askResponse.finish(false)

--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -135,7 +135,10 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
             @.newUs = _.map els, (it) ->
                 return it.id
 
-            @.loadUserstories(true)
+            @.loadUserstories(true).then (userstories) =>
+                if @scope.project.default_backlog_order_scrum == 1
+                  @.moveUsToTopOfBacklogById(element.id) for element in els
+
             @.loadProjectStats()
             @confirm.notify("success")
             @analytics.trackEvent("userstory", "create", "bulk create userstory on backlog", 1)
@@ -151,6 +154,10 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         @scope.$on "usform:new:success", (event, el) =>
             @.newUs = [el.id]
             @.loadUserstories(true)
+              .then (userstories) =>
+                if @scope.project.default_backlog_order_scrum == 1
+                  @.moveUsToTopOfBacklogById(el.id)
+
             @.loadProjectStats()
 
             @rootscope.$broadcast("filters:update")

--- a/app/coffee/modules/base.coffee
+++ b/app/coffee/modules/base.coffee
@@ -107,7 +107,8 @@ urls = {
     "project-admin-project-values-custom-fields": "/project/:project/admin/project-values/custom-fields"
     "project-admin-project-values-tags": "/project/:project/admin/project-values/tags"
     "project-admin-project-values-due-dates": "/project/:project/admin/project-values/due-dates"
-    "project-admin-project-values-kanban-power-ups": "/project/:project/admin/project-values/kanban-power-ups"
+    "project-admin-project-values-kanban-power-ups": "/project/:project/admin/project-values/kanban-power-ups",
+    "project-admin-project-values-backlog-options": "/project/:project/admin/project-values/backlog-options"
 
     "project-admin-memberships": "/project/:project/admin/memberships"
     "project-admin-roles": "/project/:project/admin/roles"

--- a/app/coffee/modules/common/lightboxes.coffee
+++ b/app/coffee/modules/common/lightboxes.coffee
@@ -559,6 +559,8 @@ $confirm, $q, attachmentsService, $template, $compile) ->
                         statusList: _.sortBy(project.us_statuses, "order")
                     }
                 initialData: (data) ->
+                    if $scope.userstories && $scope.userstories.length != 0
+                      backlog_order = if data.project.default_backlog_order_scrum == 1 then 0 else $scope.userstories[$scope.userstories.length - 1].backlog_order + 1
                     return {
                         project: data.project.id
                         subject: ""
@@ -568,6 +570,7 @@ $confirm, $q, attachmentsService, $template, $compile) ->
                         swimlane: if data.project.is_kanban_activated then data.project.default_swimlane else null
                         status: if data.statusId then data.statusId else data.project.default_us_status
                         is_archived: false
+                        backlog_order: backlog_order
                     }
             }
             task: {
@@ -1036,5 +1039,3 @@ tgResources, $tgResources, $epicsService, tgAnalytics) ->
 module.directive("tgLbRelatetoepic", [
     "$rootScope", "$tgConfirm", "lightboxService", "tgCurrentUserService", "tgResources",
     "$tgResources", "tgEpicsService", "$tgAnalytics", RelateToEpicLightboxDirective])
-
-

--- a/app/coffee/modules/kanban/main.coffee
+++ b/app/coffee/modules/kanban/main.coffee
@@ -174,6 +174,9 @@ class KanbanController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.Fi
         @scope.$on "usform:new:success", (event, us) =>
             @.refreshTagsColors().then () =>
                 @kanbanUserstoriesService.add(us)
+
+                @.orderStoriesByPreference([us])
+
                 @scope.$broadcast("redraw:wip")
 
             @analytics.trackEvent("userstory", "create", "create userstory on kanban", 1)
@@ -181,8 +184,11 @@ class KanbanController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.Fi
         @scope.$on "usform:bulk:success", (event, uss) =>
             @confirm.notify("success")
             @.refreshTagsColors().then () =>
-                @kanbanUserstoriesService.add(uss)
-                @scope.$broadcast("redraw:wip")
+              @kanbanUserstoriesService.add(uss)
+
+              @.orderStoriesByPreference(uss)
+
+              @scope.$broadcast("redraw:wip")
 
             @analytics.trackEvent("userstory", "create", "bulk create userstory on kanban", 1)
 
@@ -521,6 +527,13 @@ class KanbanController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.Fi
             , 0, true
 
         @.generateFilters()
+
+    orderStoriesByPreference: (stories) ->
+      if @scope.project.default_backlog_order_kanban != 0
+        us = stories[0]
+        columnId = "column-#{us.status}"
+        firstCardInColumn = $('#' + columnId).find('tg-card').first()
+        @scope.$broadcast("kanban:us:move", stories, us.status, us.swimlane, 0, null, firstCardInColumn)
 
     moveUs: (ctx, usList, newStatusId, newSwimlaneId, index, previousCard, nextCard) ->
         @.cleanSelectedUss()

--- a/app/locales/taiga/locale-ar.json
+++ b/app/locales/taiga/locale-ar.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Roles - {{projectName}}",
             "WARNING_NO_ROLE": "Be careful, no role in your project will be able to estimate the point value for user stories",

--- a/app/locales/taiga/locale-ca.json
+++ b/app/locales/taiga/locale-ca.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Fixar WIP limit",
             "DEFAULT": "Per defecte"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Rols - {{projectName}}",
             "WARNING_NO_ROLE": "Ves amb compte, cap rol en el teu projecte pot estimar punts per a les històries d'usuari",

--- a/app/locales/taiga/locale-da.json
+++ b/app/locales/taiga/locale-da.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Roller - {{projectName}}",
             "WARNING_NO_ROLE": "Vær påpasselig, ingen rolle i dit projekt vil kunne estimere point værdien for brugerhistorier",

--- a/app/locales/taiga/locale-de.json
+++ b/app/locales/taiga/locale-de.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "WIP-Limit",
             "DEFAULT": "Standard"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Rollen - {{projectName}}",
             "WARNING_NO_ROLE": "Beachten Sie, keine Rolle in Ihrem Projekt wird in der Lage sein, die Punktevergabe für User-Stories einzuschätzen.",

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -690,7 +690,7 @@
             "DEFAULT": "Default"
         },
         "PROJECT_BACKLOG_OPTIONS": {
-        "TITLE": "Backlog Options",
+          "TITLE": "Backlog Options",
           "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
           "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
           "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -689,6 +689,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+        "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Roles - {{projectName}}",
             "WARNING_NO_ROLE": "Be careful, no role in your project will be able to estimate the point value for user stories",
@@ -818,7 +826,8 @@
             "CUSTOM_FIELDS": "Custom fields",
             "TAGS": "Tags",
             "DUE_DATES": "Due dates",
-            "KANBAN_OPTIONS": "Kanban options"
+            "KANBAN_OPTIONS": "Kanban options",
+            "BACKLOG_OPTIONS": "Backlog options"
         },
         "SUBMENU_ROLES": {
             "TITLE": "Roles",

--- a/app/locales/taiga/locale-es.json
+++ b/app/locales/taiga/locale-es.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Establecer WIP limit",
             "DEFAULT": "Predeterminado"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Roles - {{projectName}}",
             "WARNING_NO_ROLE": "Ojo, ningún rol en tu proyecto podrá estimar historias de usuario",

--- a/app/locales/taiga/locale-eu.json
+++ b/app/locales/taiga/locale-eu.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Lehenetsia"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Rolak - {{projectName}}",
             "WARNING_NO_ROLE": "Erne, zure proiektuan ez dago rol bat ere eginkizunen balio puntuak kalkulatu dezakeenik",

--- a/app/locales/taiga/locale-fa.json
+++ b/app/locales/taiga/locale-fa.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "پیش فرض"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "نقش‌ها -  {{projectName}}",
             "WARNING_NO_ROLE": "مراقب باشید، هیچ نقشی در پروژه‌ی شما قادر به تخمین ارزش امتیازات استوری‌های کاربر نیست",

--- a/app/locales/taiga/locale-fi.json
+++ b/app/locales/taiga/locale-fi.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Roolit - {{projectName}}",
             "WARNING_NO_ROLE": "Ole varovainen, yksikään rooli projektissasi ei voi arvioida käyttäjätarinoidesi kokoa",

--- a/app/locales/taiga/locale-fr.json
+++ b/app/locales/taiga/locale-fr.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Valeur par défaut"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Rôles - {{projectName}}",
             "WARNING_NO_ROLE": "Attention, aucun rôle dans votre projet ne pourra estimer la valeur du point pour les récits utilisateurs",

--- a/app/locales/taiga/locale-he.json
+++ b/app/locales/taiga/locale-he.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "ברירת מחדל"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "תפקידים - {{projectName}}",
             "WARNING_NO_ROLE": "היה זהיר, שום תפקיד בפרוייקט זה לא יוכל להעריך את הנקודות של סיפורי המשתמש",

--- a/app/locales/taiga/locale-it.json
+++ b/app/locales/taiga/locale-it.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Predefinito"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Ruoli - {{projectName}}",
             "WARNING_NO_ROLE": "Attento, nessun ruolo, all'interno del tuo progetto, potrà stimare i punti valore per le storie utente",

--- a/app/locales/taiga/locale-ja.json
+++ b/app/locales/taiga/locale-ja.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "WIP制限設定",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "役割 - {{projectName}}",
             "WARNING_NO_ROLE": "ユーザーストーリーのポイントを見積もれる役割がプロジェクトに存在しません。",

--- a/app/locales/taiga/locale-ko.json
+++ b/app/locales/taiga/locale-ko.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "역할 - {{projectName}}",
             "WARNING_NO_ROLE": "주의하세요, 현재 프로젝트에 유저 스토리의 포인트를 산정할 수 있는 역할이 없습니다.",

--- a/app/locales/taiga/locale-lv.json
+++ b/app/locales/taiga/locale-lv.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Noklusējuma"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Lomas - {{projectName}}",
             "WARNING_NO_ROLE": "Esiet piesardzīgs, neviena no piešķirtajām lomām Jūsu projektā nevarēs novērtēt vajadzību punktu vērtību",

--- a/app/locales/taiga/locale-nb.json
+++ b/app/locales/taiga/locale-nb.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Sett VIP-begrensning",
             "DEFAULT": "Standard"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Roller - {{projectName}}",
             "WARNING_NO_ROLE": "Vær forsiktig, ingen roller i ditt prosjekt vil kunne estimere poengverdier for brukerhistorier",

--- a/app/locales/taiga/locale-nl.json
+++ b/app/locales/taiga/locale-nl.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Rollen - {{projectName}}",
             "WARNING_NO_ROLE": "Wees voorzichtig, geen enkele rol in je project zal de puntenwaarde van een user story kunnen estimeren",

--- a/app/locales/taiga/locale-pl.json
+++ b/app/locales/taiga/locale-pl.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Role - {{projectName}}",
             "WARNING_NO_ROLE": "Bez przydzielenia ról w projekcie nie ma możliwości oceniania historyjek użytkownika. Umpa Lumpy nie będą wiedziały komu wolno to zrobić :)",

--- a/app/locales/taiga/locale-pt-br.json
+++ b/app/locales/taiga/locale-pt-br.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Funções - {{projectName}}",
             "WARNING_NO_ROLE": "Seja cuidadoso, nenhuma função em seu projeto será capaz de estimar o valor dos pontos para as histórias de usuários",

--- a/app/locales/taiga/locale-ru.json
+++ b/app/locales/taiga/locale-ru.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Установить WIP лимит",
             "DEFAULT": "По умолчанию"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Роли - {{projectName}}",
             "WARNING_NO_ROLE": "Осторожнее: ни с какими ролями на вашем проекте участники не смогут оценить очки для пользовательских историй.",

--- a/app/locales/taiga/locale-sr.json
+++ b/app/locales/taiga/locale-sr.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Улоге - {{projectName}}",
             "WARNING_NO_ROLE": "Будите опрезни, ниједана улога у вашем пројекту ће моћи проценити вредност корисничке приче",

--- a/app/locales/taiga/locale-sv.json
+++ b/app/locales/taiga/locale-sv.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Roller - {{projectName}}",
             "WARNING_NO_ROLE": "Var försiktig. Inga roller i ditt projekt kan estimera poängvärden för användarhistorier",

--- a/app/locales/taiga/locale-tr.json
+++ b/app/locales/taiga/locale-tr.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Varsayılan"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Roller  - {{projectName}}",
             "WARNING_NO_ROLE": "Dikkat edin, projenizdeki rollerden hiçbiri kullanıcı hikayeleri için puan değeri kestirimi yapma yetkisine sahip değil.",

--- a/app/locales/taiga/locale-uk.json
+++ b/app/locales/taiga/locale-uk.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Типове"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Ролі - {{projectName}}",
             "WARNING_NO_ROLE": "Будьте обережні: жодна роль у вашому проєкті не зможе оцінювати значення кількості очок для історій користувача",

--- a/app/locales/taiga/locale-vi.json
+++ b/app/locales/taiga/locale-vi.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "Vai trò - {{projectName}}",
             "WARNING_NO_ROLE": "Chú ý, không vị trí nào trong dự án có thể ước tính giá trị điểm cho nhật kí người dùng",

--- a/app/locales/taiga/locale-zh-hans.json
+++ b/app/locales/taiga/locale-zh-hans.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "默认"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "角色- {{projectName}}",
             "WARNING_NO_ROLE": "注意，你的项目中无角色可以评估用户故事的点数",

--- a/app/locales/taiga/locale-zh-hant.json
+++ b/app/locales/taiga/locale-zh-hant.json
@@ -688,6 +688,14 @@
             "WIP_LIMIT_INPUT": "Set WIP limit",
             "DEFAULT": "Default"
         },
+        "PROJECT_BACKLOG_OPTIONS": {
+          "TITLE": "Backlog Options",
+          "SUBTITLE": "Options for the backlog within scrum and kanban workflows",
+          "DEFAULT_BACKLOG_ORDER_SCRUM": "Default ordering for new stories within the backlog for Scrum workflow",
+          "DEFAULT_BACKLOG_ORDER_KANBAN": "Default ordering for new stories within the backlog for Kanban workflow",
+          "TOP_OF_BACKLOG": "Top of Backlog",
+          "BOTTOM_OF_BACKLOG": "Bottom of Backlog"
+        },
         "ROLES": {
             "PAGE_TITLE": "角色- {{projectName}}",
             "WARNING_NO_ROLE": "注意，你的專案中無角色可以評估使用者故事的點數",

--- a/app/modules/services/project.service.coffee
+++ b/app/modules/services/project.service.coffee
@@ -51,6 +51,7 @@ class ProjectService
             "admin:project-values:updated"
             "admin:project-values:move"
             "admin:project-custom-attributes:updated"
+            "admin:project-values:backlog-options:updated"
             "sprintform:create:success"
             "sprintform:edit:success"
             "sprintform:remove:success"

--- a/app/partials/admin/admin-project-values-backlog-options.jade
+++ b/app/partials/admin/admin-project-values-backlog-options.jade
@@ -1,0 +1,38 @@
+doctype html
+
+div.wrapper(
+    ng-controller="ProjectValuesSectionController",
+    ng-init="sectionName='ADMIN.PROJECT_BACKLOG_OPTIONS.TITLE'"
+)
+
+    tg-project-menu
+
+    sidebar.menu-secondary.sidebar.settings-nav(tg-admin-navigation="project-values")
+        include ../includes/modules/admin-menu
+
+    sidebar.menu-tertiary.sidebar(tg-admin-navigation="values-backlog-options")
+        include ../includes/modules/admin-submenu-project-values
+
+    section.main.admin-common.admin-attributes
+        include ../includes/components/mainTitle
+        p.admin-subtitle(translate="ADMIN.PROJECT_BACKLOG_OPTIONS.SUBTITLE")
+
+        div.admin-attributes-section.admin-backlog-options(
+            tg-project-backlog-options
+            ng-controller="ProjectBacklogOptionsController as ctrl",
+            ng-init="section='admin'; resource='backlogOptions'; sectionName='ADMIN.PROJECT_KANBAN_OPTIONS.SWIMLANES'",
+        )
+
+          form(class="backlog-options")
+            fieldset
+                label(for="default_backlog_order_scrum", translate="ADMIN.PROJECT_BACKLOG_OPTIONS.DEFAULT_BACKLOG_ORDER_SCRUM")
+                select(id="default-backlog-order_scrum", ng-model="project.default_backlog_order_scrum",
+                       ng-options="boOption.key as boOption.name|translate for boOption in BACKLOG_ORDER_OPTIONS")
+
+            fieldset
+               button.btn-small(
+                   variant="primary"
+                   type="submit",
+                   title="{{'COMMON.SAVE' | translate}}"
+               )
+                   span(translate="COMMON.SAVE")

--- a/app/partials/admin/admin-project-values-backlog-options.jade
+++ b/app/partials/admin/admin-project-values-backlog-options.jade
@@ -30,6 +30,11 @@ div.wrapper(
                        ng-options="boOption.key as boOption.name|translate for boOption in BACKLOG_ORDER_OPTIONS")
 
             fieldset
+              label(for="default_backlog_order_kanban", translate="ADMIN.PROJECT_BACKLOG_OPTIONS.DEFAULT_BACKLOG_ORDER_KANBAN")
+              select(id="default-backlog-order_kanban", ng-model="project.default_backlog_order_kanban",
+                     ng-options="boOption.key as boOption.name|translate for boOption in BACKLOG_ORDER_OPTIONS")
+
+            fieldset
                button.btn-small(
                    variant="primary"
                    type="submit",

--- a/app/partials/includes/components/backlog-row.jade
+++ b/app/partials/includes/components/backlog-row.jade
@@ -62,6 +62,6 @@
 
     .us-option(tg-us-edit-selector, tg-check-permission="modify_us")
         button.us-option-popup-button.js-popup-button(
-          ng-class="{first: us.backlog_order === 0}"
+          ng-class="{first: us.is_first_in_backlog}"
         )
             tg-svg(svg-icon="icon-more-vertical")

--- a/app/partials/includes/modules/admin-submenu-project-values.jade
+++ b/app/partials/includes/modules/admin-submenu-project-values.jade
@@ -36,3 +36,7 @@ section.admin-submenu
             li#adminmenu-values-kanban-power-ups(ng-show="project.is_kanban_activated")
                 a(href="", tg-nav="project-admin-project-values-kanban-power-ups:project=project.slug")
                     span.title(translate="ADMIN.SUBMENU_PROJECT_VALUES.KANBAN_OPTIONS")
+
+            li#adminmenu-values-backlog-options(ng-show="project.is_backlog_activated")
+                a(href="", tg-nav="project-admin-project-values-backlog-options:project=project.slug")
+                    span.title(translate="ADMIN.SUBMENU_PROJECT_VALUES.BACKLOG_OPTIONS")

--- a/app/styles/layout/admin-project-values.scss
+++ b/app/styles/layout/admin-project-values.scss
@@ -314,3 +314,22 @@
         width: 500px;
     }
 }
+
+.backlog-options {
+    fieldset {
+        margin-bottom: 1rem;
+        &:last-child {
+            margin-top: 1.5rem;
+        }
+    }
+    label,
+    select {
+        display: inline-block;
+        width: 49.7%;
+    }
+    a {
+        color: $white;
+        display: block;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
Fix for https://tree.taiga.io/project/taiga/issue/4352

This adds two settings options for controlling the default backlog ordering: one each for scrum and kanban. These settings control whether new user stories are placed at the top or bottom (default) of the backlog.

Note: This depends on https://github.com/taigaio/taiga-back/pull/1616 for changes to the project model so that these settings can be saved.

**Demo**:
- https://youtu.be/2lzZg4ZKlos


