### PR TITLE
fix(front): prevent form submission while composing

### DIFF
--- a/app/coffee/modules/related-tasks.coffee
+++ b/app/coffee/modules/related-tasks.coffee
@@ -162,13 +162,14 @@ RelatedTaskCreateFormDirective = ($repo, $compile, $confirm, $tgmodel, $loading,
 
             $scope.openNewRelatedTask = true
 
-            $el.on "keyup", "input", (event)->
-                if event.keyCode == 13
-                    createTask(newTask).then ->
-                        reset()
-                        $el.find('input').focus()
+            $el.on "submit", "form", (event)->
+                event.preventDefault()
+                createTask(newTask).then ->
+                    reset()
+                    $el.find('input').focus()
 
-                else if event.keyCode == 27
+            $el.on "keyup", "input", (event)->
+                if event.keyCode == 27
                     $scope.$apply () -> close()
 
         $scope.save = () ->

--- a/app/partials/task/related-task-create-form.jade
+++ b/app/partials/task/related-task-create-form.jade
@@ -7,7 +7,8 @@
 
 .row.single-related-task.related-task-create-form.active(ng-if="openNewRelatedTask")
     .task-name
-        input(type='text', tg-autofocus, placeholder="{{'TASK.PLACEHOLDER_SUBJECT' | translate}}")
+        form
+            input(type='text', tg-autofocus, placeholder="{{'TASK.PLACEHOLDER_SUBJECT' | translate}}")
     .task-settings
         a.save-task(ng-click="save()" title="{{'COMMON.SAVE' | translate}}")
             tg-svg(svg-icon="icon-save")


### PR DESCRIPTION
hi, Taiga team.
I fix `RelatedTaskCreateForm` to prevent unexpected submission while inputting for IME users.
the app now listens to input's `Enter keydown` event to submit this form. And I will replace this with  `submit` event of the form that I added because it's too hard to handle `composition` behavior difference of `input` event between browsers.

## current behavior
https://user-images.githubusercontent.com/17243595/118767145-58e79f80-b8b8-11eb-9df0-cb085c4c34e6.mp4

typing (composing) -> press `Enter` key to end composition and submit immediately

## expected behavior(will be fixed in this PR)
https://user-images.githubusercontent.com/17243595/118767166-5d13bd00-b8b8-11eb-921c-fa44b83a8c73.mp4

typing (composing) -> press `Enter` key to end composition -> press `Enter` key again not in composition to submit form