### PR TITLE
Add default settings for move to top options.

### DIFF
--- a/app/coffee/modules/admin/project-values.coffee
+++ b/app/coffee/modules/admin/project-values.coffee
@@ -678,7 +678,14 @@ ProjectDueDatesValues = ($log, $repo, $confirm, $location, animationFrame, $tran
 
         $el.on "click", ".days-to-due-sign", (event) ->
             event.preventDefault()
+
+            currentValue = Number(angular.element(event.currentTarget).parent().find('input').val())
+
             value = _valueFromEventTarget(event)
+
+            if currentValue == value.sign
+                return
+
             $scope.$apply ->
                 value.sign = value.sign * -1
                 _setDaysToDue(value)

--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -125,7 +125,9 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
             @.newUs = _.map els, (it) ->
                 return it.id
 
-            @.loadUserstories(true)
+            @.loadUserstories(true).then (userstories) =>
+              if @scope.project.default_backlog_order_scrum == 1
+                @.moveUsToTopOfBacklogById(element.id) for element in els
             @.loadProjectStats()
             @confirm.notify("success")
             @analytics.trackEvent("userstory", "create", "bulk create userstory on backlog", 1)
@@ -140,7 +142,9 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
         @scope.$on "usform:new:success", (event, el) =>
             @.newUs = [el.id]
-            @.loadUserstories(true)
+            @.loadUserstories(true).then (userstories) =>
+              if @scope.project.default_backlog_order_scrum == 1
+                @.moveUsToTopOfBacklogById(el.id)
             @.loadProjectStats()
 
             @rootscope.$broadcast("filters:update")

--- a/app/coffee/modules/backlog/main.coffee
+++ b/app/coffee/modules/backlog/main.coffee
@@ -174,6 +174,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
         @scope.$on("sprint:us:move", @.moveUs)
         @scope.$on "sprint:us:moved", () =>
+            @.resetFirstStoryIndicator()
             @rootscope.$broadcast("filters:update")
 
         @scope.$on("backlog:load-closed-sprints", @.loadClosedSprints)
@@ -328,6 +329,7 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
             # NOTE: Fix order of USs because the filter orderBy does not work propertly in the partials files
             @scope.userstories = @scope.userstories.concat(_.sortBy(userstories, "backlog_order"))
+            @.resetFirstStoryIndicator()
             @scope.visibleUserStories = _.map @scope.userstories, (it) ->
                 return it.ref
 
@@ -433,6 +435,8 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
         @scope.usStatusById = groupBy(project.us_statuses, (x) -> x.id)
         @scope.usStatusList = _.sortBy(project.us_statuses, "id")
 
+        @.resetFirstStoryIndicator()
+
         return project
 
     loadInitialData: ->
@@ -454,14 +458,34 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
     prepareBulkUpdateData: (uses, field="backlog_order") ->
          return _.map(uses, (x) -> {"us_id": x.id, "order": x[field]})
 
+    resetFirstStoryIndicator: () ->
+      for us, key in @scope.userstories
+        @scope.userstories[key].is_first_in_backlog = false
+      if @scope.userstories.length > 0
+        @scope.userstories[0].is_first_in_backlog = true
+
+    moveUsToTopOfBacklogById: (id) ->
+      index = _.findIndex @scope.userstories, (us) ->
+        return us.id == id
+
+      @.moveUsToTopOfBacklog(@scope.userstories[index])
+
     moveUsToTopOfBacklog: (us) ->
-        self = @
-        $('.first').each(() ->
-            $(this).removeClass('first')
-        )
+      self = @
 
-        @.moveUs("sprint:us:move", [us], 0, null, null, @scope.visibleUserStories[0])
+      nextUs = @scope.userstories[0].id
+      @.moveUs("sprint:us:move", [us], 0, null, null, nextUs)
 
+    # --move us api behavior--
+    # If you are moving multiples USs you must use the bulk api
+    # If there is only one US you must use patch (repo.save)
+    #
+    # The new US position is the position of the previous US + 1.
+    # If the previous US has a position value that it is equal to
+    # other USs, you must send all the USs with that position value
+    # only if they are before of the target position with this USs
+    # if it's a patch you must add them to the header, if is a bulk
+    # you must send them with the other USs
     moveUs: (ctx, usList, newUsIndex, newSprintId, previousUs, nextUs) ->
         oldSprintId = usList[0].milestone
         project = usList[0].project
@@ -610,7 +634,8 @@ class BacklogController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.F
 
                 @q.all([
                     @.loadProjectStats(),
-                    @.loadSprints()
+                    @.loadSprints(),
+                    @.resetFirstStoryIndicator()
                 ])
             promise.then null, =>
                 askResponse.finish(false)

--- a/app/coffee/modules/kanban/main.coffee
+++ b/app/coffee/modules/kanban/main.coffee
@@ -163,6 +163,8 @@ class KanbanController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.Fi
         @scope.$on "usform:new:success", (event, us) =>
             @.refreshTagsColors().then () =>
                 @kanbanUserstoriesService.add(us)
+                @.orderStoriesByPreference([us])
+
                 @scope.$broadcast("redraw:wip")
 
             @analytics.trackEvent("userstory", "create", "create userstory on kanban", 1)
@@ -171,6 +173,8 @@ class KanbanController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.Fi
             @confirm.notify("success")
             @.refreshTagsColors().then () =>
                 @kanbanUserstoriesService.add(uss)
+                @.orderStoriesByPreference(uss)
+
                 @scope.$broadcast("redraw:wip")
 
             @analytics.trackEvent("userstory", "create", "bulk create userstory on kanban", 1)
@@ -525,6 +529,13 @@ class KanbanController extends mixOf(taiga.Controller, taiga.PageMixin, taiga.Fi
             , 0, true
 
         @.generateFilters()
+
+    orderStoriesByPreference: (stories) ->
+        if @scope.project.default_backlog_order_kanban != 0
+            us = stories[0]
+            columnId = "column-#{us.status}"
+            firstCardInColumn = $('#' + columnId).find('tg-card').first().data('id')
+            @scope.$broadcast("kanban:us:move", stories, us.status, us.swimlane, 0, null, firstCardInColumn)
 
     moveUs: (ctx, usList, newStatusId, newSwimlaneId, index, previousCard, nextCard) ->
         @.cleanSelectedUss()

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -493,7 +493,8 @@
         "PROJECT_PRESETS": {
             "MENU_TITLE": "Presets",
             "TITLE": "Default Values",
-            "SUBTITLE": "Set default values for all selector inputs."
+            "SUBTITLE": "Set default values for all selector inputs.",
+            "DEFAULT_POSITIONS_TITLE": "Default Positions"
         },
         "MEMBERSHIPS": {
             "TITLE": "Manage members",
@@ -789,6 +790,12 @@
             "LABEL_ISSUE_STATUS": "Issue status selector",
             "LABEL_PRIORITY": "Priority selector",
             "LABEL_SEVERITY": "Severity selector"
+        },
+        "DEFAULT_POSITIONS": {
+          "BACKLOG_ORDER": "User stories created on the backlog",
+          "KANBAN_ORDER": "User stories created on the kanban",
+          "TOP_OF_BACKLOG": "Top",
+          "BOTTOM_OF_BACKLOG": "Bottom"
         },
         "STATUS": {
             "PLACEHOLDER_WRITE_STATUS_NAME": "Write a name for the new status",

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -703,7 +703,7 @@
             "WARNING_DELETE_ROLE": "Be careful! All role estimations will be removed",
             "ERROR_DELETE_ALL": "You can't delete all values",
             "EXTERNAL_USER": "External user",
-            "NOTE_EXTERNAL_USERS": "<strong>Note:</strong> by External User we mean any anonymous user not belonging to the Taiga platform, including search engines. Please use this role with care."
+            "NOTE_EXTERNAL_USERS": "An external user is any user (logged in to the Taiga platform or not), including search engines. Although unregistered users can never have edit permissions, registered users can, if you allow it. If your project is private, you can also control viewing permissions. Please, use this role with care."
         },
         "THIRD_PARTIES": {
             "SECRET_KEY": "Secret key",

--- a/app/modules/services/project.service.coffee
+++ b/app/modules/services/project.service.coffee
@@ -36,6 +36,7 @@ class ProjectService
         fetchRequiredSignals = [
             "admin:project-modules:updated"
             "admin:project-roles:updated"
+            "admin:project-default-positions:updated"
             "admin:project-default-values:updated"
             "admin:project-values:updated"
             "admin:project-values:move"

--- a/app/partials/includes/components/backlog-row.jade
+++ b/app/partials/includes/components/backlog-row.jade
@@ -69,6 +69,6 @@
 
     .us-option(tg-us-edit-selector, tg-check-permission="modify_us")
         button.us-option-popup-button.js-popup-button(
-          ng-class="{first: us.backlog_order === 0}"
+          ng-class="{first: us.is_first_in_backlog}"
         )
             tg-svg(svg-icon="icon-more-vertical")

--- a/app/partials/includes/modules/admin/default-values.jade
+++ b/app/partials/includes/modules/admin/default-values.jade
@@ -6,7 +6,7 @@
 //- Copyright (c) 2021-present Kaleidos Ventures SL
 
 section.default-values
-    form
+    form.default-values
 
         //- Epics
         fieldset
@@ -52,10 +52,24 @@ section.default-values
             select(id="default-value-severity", ng-model="project.default_severity",
                    ng-options="s.id as s.name for s in severitiesList")
 
-        fieldset
-            button.btn-small(
-                variant="primary"
-                type="submit",
-                title="{{'COMMON.SAVE' | translate}}"
-            )
-                span(translate="COMMON.SAVE")
+section.default-positions
+    h1.title {{ 'ADMIN.PROJECT_PRESETS.DEFAULT_POSITIONS_TITLE' | translate }}
+
+    form.default-positions
+      fieldset
+          label(for="default_backlog_order_scrum", translate="ADMIN.DEFAULT_POSITIONS.BACKLOG_ORDER")
+          select(id="default-backlog-order_scrum", ng-model="project.default_backlog_order_scrum",
+                 ng-options="boOption.key as boOption.name|translate for boOption in BACKLOG_ORDER_OPTIONS")
+
+      fieldset
+          label(for="default_backlog_order_kanban", translate="ADMIN.DEFAULT_POSITIONS.KANBAN_ORDER")
+          select(id="default-backlog-order_kanban", ng-model="project.default_backlog_order_kanban",
+                 ng-options="boOption.key as boOption.name|translate for boOption in BACKLOG_ORDER_OPTIONS")
+
+      fieldset
+          button.btn-small(
+              variant="primary"
+              type="submit",
+              title="{{'COMMON.SAVE' | translate}}"
+          )
+              span(translate="COMMON.SAVE")

--- a/app/styles/modules/admin/default-values.scss
+++ b/app/styles/modules/admin/default-values.scss
@@ -1,4 +1,5 @@
-.default-values {
+.default-values,
+.default-positions {
     fieldset {
         margin-bottom: 1rem;
         &:last-child {
@@ -15,4 +16,8 @@
         display: block;
         text-align: center;
     }
+}
+
+section.default-positions {
+    margin-top: 4em;
 }

--- a/app/styles/modules/common/colors-table.scss
+++ b/app/styles/modules/common/colors-table.scss
@@ -143,29 +143,32 @@
                 background: rgba($whitish, .7);
                 cursor: pointer;
                 display: block;
-                padding: .5rem .25rem;
+                padding: .5rem 1rem;
                 text-align: center;
-                text-transform: uppercase;
-                transition: background .2s ease-in;
+                transition: background color .2s ease-in;
             }
             +label:hover {
                 background: rgba($primary-light, .3);
-                transition: background .2s ease-in;
+                transition: background color .2s ease-in;
             }
         }
         .before-after-selector-single {
-            flex: 1;
-            margin-right: .25rem;
+            overflow: hidden;
+            &:first-child {
+                border-radius: .25rem 0 0 .25rem;
+            }
             &:last-child {
+                border-radius: 0 .25rem .25rem 0;
                 margin-right: 0;
             }
             &.checked label {
-                background: $primary-light;
+                background: $color-link-primary;
                 color: $white;
                 transition: background .2s ease-in;
             }
-            &.checked label:hover {
-                background: $primary-light;
+            &:not(.checked) label:hover {
+                background: rgba($color-link-primary, .3);
+                color: $color-black600;
             }
         }
     }


### PR DESCRIPTION
Fix for https://tree.taiga.io/project/taiga/issue/4352

This adds two settings options for controlling the default backlog ordering: one each for scrum and kanban. These settings control whether new user stories are placed at the top or bottom (default) of the backlog.

Note: This depends on taigaio/taiga-back#1616 for changes to the project model so that these settings can be saved.

Demo:
  - https://youtu.be/2lzZg4ZKlos
