### PR TITLE
fix: use pointerenter instead of mouseenter

### DIFF
--- a/app/coffee/modules/base/navurls.coffee
+++ b/app/coffee/modules/base/navurls.coffee
@@ -98,7 +98,7 @@ NavigationUrlsDirective = ($navurls, $auth, $q, $location, lightboxService, tgSe
         if $el.is("a")
             $el.attr("href", "#")
 
-        $el.on "mouseenter", (event) ->
+        $el.on "pointerenter", (event) ->
             target = $(event.currentTarget)
 
             if !target.data("fullUrl") || $attrs.tgNavGetParams != target.data("params")


### PR DESCRIPTION
I tried to make this directive working on mobile devices and "pointerenter" looks to be a possible solution to support both desktop and mobile. 