### PR TITLE
fix(kanban): Fix upside-down Chinese characters on vertical writing.

### DIFF
--- a/app/styles/modules/kanban/kanban-table.scss
+++ b/app/styles/modules/kanban/kanban-table.scss
@@ -376,7 +376,6 @@ body {
         flex-direction: row-reverse;
         padding: 1rem 0;
         text-transform: uppercase;
-        transform: rotate(-180deg);
         width: 100%;
         writing-mode: tb-rl;
     }


### PR DESCRIPTION
Hi.
There is a style that I'm concerned in kanban.
When I fold title, words transform vertical line by `transform: rotate(-180deg);` . But Chinese characters and Japanese Kana are automatically transposed. So these actions do together and these words are upside-down.
I think it is better to delete this style.

![taiga](https://user-images.githubusercontent.com/8765579/142767728-a6e1b93f-5f05-4573-b6f7-e97468ca1e77.jpg)

