### PR TITLE
fix: prevent overflowing texts

### DIFF
--- a/app/modules/components/detail/header/detail-header.scss
+++ b/app/modules/components/detail/header/detail-header.scss
@@ -105,6 +105,7 @@
     .detail-subject {
         color: $color-black900;
         flex-grow: 1;
+        word-break: break-all;
     }
     .edit-title-input {
         font-size: 1.2rem;

--- a/app/modules/components/issues-table/issues/issues-table.scss
+++ b/app/modules/components/issues-table/issues/issues-table.scss
@@ -194,6 +194,7 @@
             color: $color-black900;
             display: flex;
             margin-inline-end: .75rem;
+            word-break: break-all;
         }
         .due-date,
         .blocked {

--- a/app/modules/components/wysiwyg/wysiwyg.scss
+++ b/app/modules/components/wysiwyg/wysiwyg.scss
@@ -8,6 +8,7 @@ tg-wysiwyg {
     }
     .editor {
         width: 100%;
+        word-break: break-all;
     }
     .tools {
         display: none;

--- a/app/modules/history/comments/comment.scss
+++ b/app/modules/history/comments/comment.scss
@@ -160,6 +160,7 @@
 
 .comment-text {
     max-width: 80rem;
+    word-break: break-all;
     &.wysiwyg {
         margin-bottom: 0;
         padding: 0;

--- a/app/modules/user-timeline/user-timeline/user-timeline.scss
+++ b/app/modules/user-timeline/user-timeline/user-timeline.scss
@@ -6,6 +6,7 @@
         position: relative;
         p {
             margin-bottom: 0;
+            word-break: break-all;
         }
         a,
         .username {

--- a/app/styles/modules/backlog/backlog-table.scss
+++ b/app/styles/modules/backlog/backlog-table.scss
@@ -216,6 +216,7 @@
         flex: 1;
         flex-wrap: wrap;
         row-gap: .25rem;
+        word-break: break-all;
     }
 }
 


### PR DESCRIPTION
hi, taiga team!
I fix some layout bugs with overflowing texts
we get the send button which is not pushed away by the long URL in the comment editor.

| target | before | after |
:--:|:--:|:--:|
component: .comment-main | ![image](https://user-images.githubusercontent.com/17243595/146749837-2092a51a-daf0-4208-a012-4cf01294ee0c.png) | ![image](https://user-images.githubusercontent.com/17243595/146749849-6258238f-3866-4b23-b32a-4c6007e533e0.png) |
page: /project/P_ID/timeline | ![image](https://user-images.githubusercontent.com/17243595/146749977-a4c014dd-b9a9-4e91-ab52-940215d6297a.png) | ![image](https://user-images.githubusercontent.com/17243595/146750050-8ab5d0ce-1eec-41f4-8d48-60abc6422d62.png) |
page: /project/P_ID/backlog | ![image](https://user-images.githubusercontent.com/17243595/146750075-841d7371-9ed6-4102-8d46-31c7477a68e4.png) | ![image](https://user-images.githubusercontent.com/17243595/146750091-bac20485-c3ae-4107-a3d4-36475209867b.png) |
page: /project/P_ID/issue/I_ID, project/P_ID/us/US_ID | ![image](https://user-images.githubusercontent.com/17243595/146749628-c4972361-2353-4d8b-95fc-86a4d06d68a1.png) | ![image](https://user-images.githubusercontent.com/17243595/146749644-62faf508-61e8-405f-ba81-542a65e73697.png) |
page: /project/P_ID/issues | ![image](https://user-images.githubusercontent.com/17243595/146750292-9d75d8ed-9587-410f-a8df-afbb93e99be4.png) | ![image](https://user-images.githubusercontent.com/17243595/146750328-115dd1b4-a2cf-4e12-946f-afe240632b15.png) |


