### PR TITLE
fix: Switch from break:all to break:word

### DIFF
--- a/app/modules/components/detail/header/detail-header.scss
+++ b/app/modules/components/detail/header/detail-header.scss
@@ -105,7 +105,7 @@
     .detail-subject {
         color: $color-black900;
         flex-grow: 1;
-        word-break: break-all;
+        word-break: break-word;
     }
     .edit-title-input {
         font-size: 1.2rem;

--- a/app/modules/components/issues-table/issues/issues-table.scss
+++ b/app/modules/components/issues-table/issues/issues-table.scss
@@ -194,7 +194,7 @@
             color: $color-black900;
             display: flex;
             margin-inline-end: .75rem;
-            word-break: break-all;
+            word-break: break-word;
         }
         .due-date,
         .blocked {

--- a/app/modules/components/wysiwyg/wysiwyg.scss
+++ b/app/modules/components/wysiwyg/wysiwyg.scss
@@ -8,7 +8,7 @@ tg-wysiwyg {
     }
     .editor {
         width: 100%;
-        word-break: break-all;
+        word-break: break-word;
     }
     .tools {
         display: none;

--- a/app/modules/history/comments/comment.scss
+++ b/app/modules/history/comments/comment.scss
@@ -160,7 +160,7 @@
 
 .comment-text {
     max-width: 80rem;
-    word-break: break-all;
+    word-break: break-word;
     &.wysiwyg {
         margin-bottom: 0;
         padding: 0;

--- a/app/modules/user-timeline/user-timeline/user-timeline.scss
+++ b/app/modules/user-timeline/user-timeline/user-timeline.scss
@@ -6,7 +6,7 @@
         position: relative;
         p {
             margin-bottom: 0;
-            word-break: break-all;
+            word-break: break-word;
         }
         a,
         .username {

--- a/app/styles/modules/backlog/backlog-table.scss
+++ b/app/styles/modules/backlog/backlog-table.scss
@@ -216,7 +216,7 @@
         flex: 1;
         flex-wrap: wrap;
         row-gap: .25rem;
-        word-break: break-all;
+        word-break: break-word;
     }
 }
 


### PR DESCRIPTION
Restore text break and convert break all to break word to avoid random word break on the middle of a sentence.