### PR TITLE
Fix encoding of special characters

### DIFF
--- a/app/partials/includes/modules/search-results/search-result-table-epics.jade
+++ b/app/partials/includes/modules/search-results/search-result-table-epics.jade
@@ -19,7 +19,7 @@ div.search-result-table-container(ng-class="{'hidden': !epics.length}", tg-bind-
                         tg-nav="project-epics-detail:project=project.slug,ref=epic.ref"
                     )
                         span.ref(tg-bo-ref="epic.ref")
-                        span {{ epic.subject | emojify }}
+                        span(ng-bind-html="epic.subject | emojify")
             div.status(tg-listitem-epic-status="epic")
 
 div.empty-large(ng-class="{'hidden': epics.length}")

--- a/app/partials/includes/modules/search-results/search-result-table-issues.jade
+++ b/app/partials/includes/modules/search-results/search-result-table-issues.jade
@@ -16,11 +16,11 @@ div.search-result-table-container(ng-class="{'hidden': !issues.length}", tg-bind
             div.user-stories
                 div.user-story-name
                     a(
-                        href="", 
+                        href="",
                         tg-nav="project-issues-detail:project=project.slug,ref=issue.ref"
                     )
                         span.ref(tg-bo-ref="issue.ref")
-                        span {{ issue.subject | emojify }}
+                        span(ng-bind-html="issue.subject | emojify")
             div.status(tg-listitem-issue-status="issue")
             div.assigned-to(tg-listitem-assignedto="issue")
 

--- a/app/partials/includes/modules/search-results/search-result-table-tasks.jade
+++ b/app/partials/includes/modules/search-results/search-result-table-tasks.jade
@@ -20,7 +20,7 @@ div.search-result-table-container(ng-class="{'hidden': !tasks.length}", tg-bind-
                         tg-nav="project-tasks-detail:project=project.slug,ref=task.ref"
                     )
                         span.ref(tg-bo-ref="task.ref")
-                        span {{ task.subject | emojify }}
+                        span(ng-bind-html="task.subject | emojify")
             div.status(tg-listitem-task-status="task")
             div.assigned-to(tg-listitem-assignedto="task")
 

--- a/app/partials/includes/modules/search-results/search-result-table-us.jade
+++ b/app/partials/includes/modules/search-results/search-result-table-us.jade
@@ -16,12 +16,12 @@ div.search-result-table-container(ng-class="{'hidden': !userstories.length}", tg
         div.row.table-main(ng-repeat="us in userstories track by us.id")
             div.user-stories
                 div.user-story-name
-                    a(  
+                    a(
                         href=""
                         tg-nav="project-userstories-detail:project=project.slug,ref=us.ref"
                     )
                         span.ref(tg-bo-ref="us.ref")
-                        span {{ us.subject | emojify }}
+                        span(ng-bind-html="us.subject | emojify")
             div.sprint
                 div.sprint-link
                     a(href="", tg-nav="project-taskboard:project=project.slug,sprint=us.milestone_slug",


### PR DESCRIPTION
If the subject of an entity (issue, story etc.) contains a special character like `"` the HTML encoded version is shown in the search result view.

This PR solves #151.