### PR TITLE
Fix US subject displayed in US list of an epic

### DIFF
--- a/app/coffee/modules/common/filters.coffee
+++ b/app/coffee/modules/common/filters.coffee
@@ -134,7 +134,7 @@ module.filter("inArray", ["$filter", inArray])
 emojify = ($emojis) ->
     return (input) ->
         if input
-            return $emojis.replaceEmojiNameByHtmlImgs(_.escape(input))
+            return _.unescape($emojis.replaceEmojiNameByHtmlImgs(_.escape(input)))
 
         return ""
 


### PR DESCRIPTION
This merge request introduces a fix of the rendering of a User Story subject shown on an Epic.

Before the fix the subject was rendered with html encoded : `corriger l&#39;inventaire` whereas the expected rendering was `corriger l'inventaire`