### PR TITLE
Remove taiga-next Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ## Taiga Front
 
-&gt; **READ THIS FIRST!**: We recently announced Taiga plans for the future and they greatly affect how we manage this repository and the current Taiga 6 release. Check it [here](https://blog.taiga.io/announcing_taiganext.html).
-
 [![Managed with Taiga.io](https://img.shields.io/badge/managed%20with-TAIGA.io-709f14.svg)](https://tree.taiga.io/project/taiga/ "Managed with Taiga.io")
 [![Build Status](https://img.shields.io/travis/taigaio/taiga-front.svg)](https://travis-ci.org/taigaio/taiga-front "Build Status")
 


### PR DESCRIPTION
Taiga-next never happened, and tenzu appears to be something else now. Taiga still continues development here, so I think this reference should be removed again.