### PR TITLE
fix(notifications): open notification links in new tab on middle/ctrl-click

### DIFF
--- a/app/modules/notifications/notifications-list/notifications-list.jade
+++ b/app/modules/notifications/notifications-list/notifications-list.jade
@@ -44,7 +44,7 @@ section.notifications-list
                     p(tg-compile-html="notification.get('title_html')")
                     .entry-extra-data
                         a.entry-project(
-                            href=""
-                            ng-click="vm.setAsRead(notification, notification.get('projectUrl'))"
+                            ng-href="{{::notification.get('projectUrl')}}"
+                            ng-click="vm.setAsRead(notification, notification.get('projectUrl'), $event)"
                         ) {{::notification.getIn(['data', 'project', 'name'])}}
                         .entry-date {{::notification.get('created') | momentFromNow}}

--- a/app/modules/notifications/notifications.controller.coffee
+++ b/app/modules/notifications/notifications.controller.coffee
@@ -70,7 +70,19 @@ class NotificationsController extends mixOf(taiga.Controller, taiga.PageMixin, t
                 @.loading = false
                 return @.notificationsList
 
-    setAsRead: (notification, url) ->
+    setAsRead: (notification, url, event) ->
+        # Modifier-clicks (ctrl/cmd/shift, and the legacy middle-click some
+        # browsers still report as a click) follow the real href to open a new
+        # tab/window natively, so here we only mark the notification as read.
+        if event? and (event.ctrlKey or event.metaKey or event.shiftKey or event.which > 1)
+            @notificationsService.setNotificationAsRead(notification.get("id")).then(angular.noop, angular.noop)
+            @rootScope.$broadcast "notifications:dismiss"
+            return
+
+        # Plain left-click: navigate within the SPA ourselves, so prevent the
+        # browser from also following the href (which would full-reload the page).
+        event.preventDefault() if event?
+
         @notificationsService.setNotificationAsRead(notification.get("id")).then =>
             if @location.$$url == url
                 @window.location.reload()

--- a/app/modules/notifications/notifications.service.coffee
+++ b/app/modules/notifications/notifications.service.coffee
@@ -148,10 +148,11 @@ class NotificationsService extends taiga.Service
             .attr('ng-non-bindable', true)
             .text(text)
 
-        return $('<a href="">')
+        return $('<a>')
+            .attr('href', url)
             .attr('title', title)
             .attr('class', css)
-            .attr('ng-click', "vm.setAsRead(notification, \"#{url}\")")
+            .attr('ng-click', "vm.setAsRead(notification, \"#{url}\", $event)")
             .append(span)
             .prop('outerHTML')
 


### PR DESCRIPTION
## Summary

Fixes #228.

On the **Notifications** page, middle-clicking (or ctrl/cmd-clicking) a notification link opened the Taiga home page instead of the linked issue / user story / task. A normal left-click worked, but only because navigation was wired through an `ng-click` handler.

## Root cause

Notification links are generated with an **empty `href`** — the real target URL is only placed in an `ng-click` handler:

```coffee
# notifications.service.coffee — _getLink (used for the user, project and object links)
$('<a href="">')
  .attr('ng-click', "vm.setAsRead(notification, \"#{url}\")")
```

The same empty-`href` pattern is used for the inline project link in `notifications-list.jade`. Because `index.jade` declares `<base href="/">`, an empty `href` resolves to the site root. A left-click is intercepted by `ng-click` and navigates correctly, but **middle-click and ctrl/cmd-click bypass the JS handler and follow the (empty → root) href**, landing on the home page.

## Fix

Give the anchors a real `href` (the same URL already passed to `setAsRead`) and forward `$event` to `setAsRead`:

- **Plain left-click** — `setAsRead` calls `event.preventDefault()` and navigates within the SPA via `$location.path(url)` (unchanged behaviour; no full page reload).
- **Middle-click / ctrl / cmd / shift** — the click falls through to the browser, which opens the real href in a new tab/window.

Files changed:

- `app/modules/notifications/notifications.service.coffee` — `_getLink` emits a real `href` and forwards `$event`.
- `app/modules/notifications/notifications.controller.coffee` — `setAsRead` accepts `$event` and only `preventDefault`s a plain left-click.
- `app/modules/notifications/notifications-list/notifications-list.jade` — the `.entry-project` link uses `ng-href` instead of `href=""`.

## Testing

Manual, on the `/notifications` page:

- Left-click a notification → navigates to the item in the same tab and marks it read (as before).
- **Middle-click** → opens the item in a new tab (previously opened the home page). ✅
- **Ctrl/Cmd-click** → opens the item in a new background tab (previously opened the home page). ✅
- The project-name link under each entry behaves the same way.

Note: on modern browsers a *pure* middle-click does not fire a `click` event (it fires `auxclick`), so the item opens in the new tab but the source notification is not marked read on middle-click. This is inherent to the browser event model, not a regression in this change.

---

Prepared with AI assistance (Claude) and reviewed by the submitter, who signs off under the DCO.
